### PR TITLE
Add an option to enable CPU intrinsics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ rand = "0.8.4"
 rand_chacha = "0.3.1"
 bincode = "1.3.3"
 
+[features]
+default = []
+intrinsics = []
+
 [workspace]
 members = [
     "bench",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sucds = { path = ".." }
+# sucds = { path = ".." }
+sucds = { path = "..", features = ["intrinsics"] } # Recommend to set RUSTFLAGS="-C target-cpu=native"
 rand = "0.8.4"
 rand_chacha = "0.3.1"
 bincode = "1.3.3"

--- a/src/broadword.rs
+++ b/src/broadword.rs
@@ -1,5 +1,8 @@
 #![cfg(target_pointer_width = "64")]
 
+#[cfg(feature = "intrinsics")]
+use crate::intrinsics;
+
 pub const ONES_STEP_4: usize = 0x1111111111111111;
 pub const ONES_STEP_8: usize = 0x0101010101010101;
 pub const ONES_STEP_9: usize = 1 << 0 | 1 << 9 | 1 << 18 | 1 << 27 | 1 << 36 | 1 << 45 | 1 << 54;
@@ -35,8 +38,14 @@ pub const fn bytes_sum(x: usize) -> usize {
 }
 
 #[inline(always)]
-pub const fn popcount(x: usize) -> usize {
+#[cfg(not(feature = "intrinsics"))]
+pub fn popcount(x: usize) -> usize {
     bytes_sum(byte_counts(x))
+}
+#[inline(always)]
+#[cfg(feature = "intrinsics")]
+pub fn popcount(x: usize) -> usize {
+    intrinsics::popcount(x)
 }
 
 #[inline(always)]
@@ -45,7 +54,16 @@ pub fn select_in_word(x: usize, k: usize) -> usize {
     let byte_sums = ONES_STEP_8.wrapping_mul(byte_counts(x));
     let k_step_8 = k * ONES_STEP_8;
     let geq_k_step_8 = ((k_step_8 | MSBS_STEP_8) - byte_sums) & MSBS_STEP_8;
-    let place = popcount(geq_k_step_8) * 8;
+    let place = {
+        #[cfg(feature = "intrinsics")]
+        {
+            popcount(geq_k_step_8) * 8
+        }
+        #[cfg(not(feature = "intrinsics"))]
+        {
+            ((geq_k_step_8 >> 7).wrapping_mul(ONES_STEP_8) >> 53) & !0x7
+        }
+    };
     let byte_rank = k - (((byte_sums << 8) >> place) & 0xFF);
     place + SELECT_IN_BYTE[((x >> place) & 0xFF) | (byte_rank << 8)] as usize
 }
@@ -132,6 +150,7 @@ pub fn bit_position(x: usize) -> usize {
 }
 
 #[inline(always)]
+#[cfg(not(feature = "intrinsics"))]
 pub fn lsb(x: usize) -> Option<usize> {
     if x == 0 {
         None
@@ -139,8 +158,14 @@ pub fn lsb(x: usize) -> Option<usize> {
         Some(bit_position(x & std::usize::MAX.wrapping_mul(x)))
     }
 }
+#[inline(always)]
+#[cfg(feature = "intrinsics")]
+pub fn lsb(x: usize) -> Option<usize> {
+    intrinsics::bsf64(x)
+}
 
 #[inline(always)]
+#[cfg(not(feature = "intrinsics"))]
 pub fn msb(mut x: usize) -> Option<usize> {
     if x == 0 {
         return None;
@@ -157,6 +182,11 @@ pub fn msb(mut x: usize) -> Option<usize> {
     // isolate the MSB
     x ^= x >> 1;
     Some(bit_position(x))
+}
+#[inline(always)]
+#[cfg(feature = "intrinsics")]
+pub fn msb(x: usize) -> Option<usize> {
+    intrinsics::bsr64(x)
 }
 
 #[cfg(test)]

--- a/src/broadword.rs
+++ b/src/broadword.rs
@@ -39,12 +39,12 @@ pub const fn bytes_sum(x: usize) -> usize {
 
 #[inline(always)]
 #[cfg(not(feature = "intrinsics"))]
-pub fn popcount(x: usize) -> usize {
+pub const fn popcount(x: usize) -> usize {
     bytes_sum(byte_counts(x))
 }
 #[inline(always)]
 #[cfg(feature = "intrinsics")]
-pub fn popcount(x: usize) -> usize {
+pub const fn popcount(x: usize) -> usize {
     intrinsics::popcount(x)
 }
 
@@ -160,7 +160,7 @@ pub fn lsb(x: usize) -> Option<usize> {
 }
 #[inline(always)]
 #[cfg(feature = "intrinsics")]
-pub fn lsb(x: usize) -> Option<usize> {
+pub const fn lsb(x: usize) -> Option<usize> {
     intrinsics::bsf64(x)
 }
 
@@ -185,7 +185,7 @@ pub fn msb(mut x: usize) -> Option<usize> {
 }
 #[inline(always)]
 #[cfg(feature = "intrinsics")]
-pub fn msb(x: usize) -> Option<usize> {
+pub const fn msb(x: usize) -> Option<usize> {
     intrinsics::bsr64(x)
 }
 

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,0 +1,24 @@
+#![cfg(feature = "intrinsics")]
+
+#[inline(always)]
+pub fn popcount(x: usize) -> usize {
+    x.count_ones() as usize
+}
+
+#[inline(always)]
+pub fn bsf64(mask: usize) -> Option<usize> {
+    if mask != 0 {
+        Some(mask.trailing_zeros() as usize)
+    } else {
+        None
+    }
+}
+
+#[inline(always)]
+pub fn bsr64(mask: usize) -> Option<usize> {
+    if mask != 0 {
+        Some(63 - mask.leading_zeros() as usize)
+    } else {
+        None
+    }
+}

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,12 +1,12 @@
 #![cfg(feature = "intrinsics")]
 
 #[inline(always)]
-pub fn popcount(x: usize) -> usize {
+pub const fn popcount(x: usize) -> usize {
     x.count_ones() as usize
 }
 
 #[inline(always)]
-pub fn bsf64(mask: usize) -> Option<usize> {
+pub const fn bsf64(mask: usize) -> Option<usize> {
     if mask != 0 {
         Some(mask.trailing_zeros() as usize)
     } else {
@@ -15,7 +15,7 @@ pub fn bsf64(mask: usize) -> Option<usize> {
 }
 
 #[inline(always)]
-pub fn bsr64(mask: usize) -> Option<usize> {
+pub const fn bsr64(mask: usize) -> Option<usize> {
     if mask != 0 {
         Some(63 - mask.leading_zeros() as usize)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bit_vector;
 pub mod broadword;
 pub mod darray;
 pub mod elias_fano;
+pub mod intrinsics;
 pub mod rs_bit_vector;
 
 pub use bit_vector::BitVector;


### PR DESCRIPTION
I added an option to enable CPU intrinsics for broadword programing.

For this, I employed some bitwise operations provided by built-in integer types such as `.count_ones`. These do not ensure to use CPU intrinsics, but by setting `RUSTFLAGS="-C target-cpu=native"` it is expected to use the intrinsics (when your machine supports).

 -  cf. https://stackoverflow.com/questions/69901929/how-to-use-builtin-clzll-in-rust

Note that I did not use `std::intrinsics` because it  is a nightly-only experimental API. 

 - cf. https://doc.rust-lang.org/std/intrinsics/index.html

I measured the time performance with [the code](https://github.com/kampersanda/sucds/tree/main/bench) on one core of octa-core Intel Core i7-10700 CPU @ 2.90GHz in a machine with 16GB of RAM running the 64-bit version of Ubuntu 20.04 LTS working on WSL2. In this version, the performance was mostly improved as follows.

```
$ RUSTFLAGS="-C target-cpu=native" cargo bench
timing_rank_50/sucds/RsBitVector
                        time:   [2.0836 us 2.0859 us 2.0883 us]
                        change: [-10.920% -10.646% -10.401%] (p = 0.00 < 0.05)
                        Performance has improved.
timing_rank_50/sucds/EliasFano
                        time:   [14.632 us 14.654 us 14.675 us]
                        change: [-13.673% -13.477% -13.302%] (p = 0.00 < 0.05)
                        Performance has improved.

timing_rank_10/sucds/RsBitVector
                        time:   [2.0411 us 2.0433 us 2.0457 us]
                        change: [-11.989% -11.861% -11.727%] (p = 0.00 < 0.05)
                        Performance has improved.
timing_rank_10/sucds/EliasFano
                        time:   [10.954 us 10.971 us 10.989 us]
                        change: [-26.368% -26.167% -25.961%] (p = 0.00 < 0.05)
                        Performance has improved.

timing_rank_1/sucds/RsBitVector
                        time:   [2.1178 us 2.1229 us 2.1288 us]
                        change: [+5.7651% +6.0569% +6.3849%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 30 measurements (13.33%)
  4 (13.33%) high severe
timing_rank_1/sucds/EliasFano
                        time:   [9.9349 us 9.9509 us 9.9677 us]
                        change: [-23.271% -23.080% -22.882%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild

timing_select_50/sucds/RsBitVector
                        time:   [46.591 us 46.651 us 46.715 us]
                        change: [-2.8306% -2.6563% -2.4783%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
timing_select_50/sucds/DArray
                        time:   [7.7626 us 7.7786 us 7.7948 us]
                        change: [-2.3508% -2.0623% -1.7770%] (p = 0.00 < 0.05)
                        Performance has improved.
timing_select_50/sucds/EliasFano
                        time:   [11.082 us 11.102 us 11.125 us]
                        change: [-0.5960% -0.3184% -0.0352%] (p = 0.03 < 0.05)
                        Change within noise threshold.

timing_select_10/sucds/RsBitVector
                        time:   [46.396 us 46.468 us 46.551 us]
                        change: [-3.2222% -3.0312% -2.8332%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
timing_select_10/sucds/DArray
                        time:   [11.053 us 11.070 us 11.087 us]
                        change: [-4.5669% -4.3473% -4.1178%] (p = 0.00 < 0.05)
                        Performance has improved.
timing_select_10/sucds/EliasFano
                        time:   [9.1723 us 9.1868 us 9.2015 us]
                        change: [-3.3745% -3.1368% -2.8841%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  1 (3.33%) low mild
  1 (3.33%) high mild

timing_select_1/sucds/RsBitVector
                        time:   [46.910 us 46.970 us 47.038 us]
                        change: [-1.4342% -1.2407% -1.0525%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  3 (10.00%) high mild
timing_select_1/sucds/DArray
                        time:   [1.4270 us 1.4301 us 1.4340 us]
                        change: [+2.5847% +2.8867% +3.2210%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 30 measurements (10.00%)
  2 (6.67%) high mild
  1 (3.33%) high severe
timing_select_1/sucds/EliasFano
                        time:   [8.3499 us 8.3639 us 8.3791 us]
                        change: [-2.4734% -2.2141% -1.9512%] (p = 0.00 < 0.05)
                        Performance has improved.
```