### PR TITLE
Remove serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
+byteorder = "1.4.3"
+num-traits = "0.2.14"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 byteorder = "1.4.3"
 num-traits = "0.2.14"
@@ -23,7 +22,6 @@ num-traits = "0.2.14"
 [dev-dependencies]
 rand = "0.8.4"
 rand_chacha = "0.3.1"
-bincode = "1.3.3"
 
 [features]
 default = []

--- a/bench/src/memory.rs
+++ b/bench/src/memory.rs
@@ -21,31 +21,31 @@ fn show_memories(p: f64) {
 
     let bytes = {
         let idx = sucds::RsBitVector::from_bits(&bits, false, false);
-        bincode::serialize(&idx).unwrap().len()
+        idx.size_in_bytes()
     };
     print_memory("RsBitVector(false,false)", bytes);
 
     let bytes = {
         let idx = sucds::RsBitVector::from_bits(&bits, true, true);
-        bincode::serialize(&idx).unwrap().len()
+        idx.size_in_bytes()
     };
     print_memory("RsBitVector(true,true)", bytes);
 
     let bytes = {
         let idx = sucds::DArray::from_bits(&bits);
-        bincode::serialize(&idx).unwrap().len()
+        idx.size_in_bytes()
     };
     print_memory("DArray", bytes);
 
     let bytes = {
         let idx = sucds::EliasFano::from_bits(&bits, false).unwrap();
-        bincode::serialize(&idx).unwrap().len()
+        idx.size_in_bytes()
     };
     print_memory("EliasFano(false)", bytes);
 
     let bytes = {
         let idx = sucds::EliasFano::from_bits(&bits, true).unwrap();
-        bincode::serialize(&idx).unwrap().len()
+        idx.size_in_bytes()
     };
     print_memory("EliasFano(true)", bytes);
 }

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -607,8 +607,9 @@ mod tests {
     fn test_serialize() {
         let mut bytes = vec![];
         let bv = BitVector::from_bits(&gen_random_bits(10000, 42));
-        bv.serialize_into(&mut bytes).unwrap();
+        let size = bv.serialize_into(&mut bytes).unwrap();
         let other = BitVector::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(bv, other);
+        assert_eq!(size, bytes.len());
     }
 }

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -1,10 +1,10 @@
-use crate::{broadword, util};
-
 use std::io::{Read, Write};
 use std::mem::size_of;
 
 use anyhow::Result;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::{broadword, util};
 
 const WORD_LEN: usize = std::mem::size_of::<usize>() * 8;
 
@@ -461,15 +461,19 @@ impl BitVector {
     }
 
     pub fn serialize_into<W: Write>(&self, mut writer: W) -> Result<usize> {
-        let mem = util::serialize_int_vector(&self.words, &mut writer)?;
+        let mem = util::int_vector::serialize_into(&self.words, &mut writer)?;
         writer.write_u64::<LittleEndian>(self.len as u64)?;
         Ok(mem + size_of::<u64>())
     }
 
     pub fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
-        let words = util::deserialize_int_vector(&mut reader)?;
+        let words = util::int_vector::deserialize_from(&mut reader)?;
         let len = reader.read_u64::<LittleEndian>()? as usize;
         Ok(Self { words, len })
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        util::int_vector::size_in_bytes(&self.words) + size_of::<u64>()
     }
 }
 
@@ -611,5 +615,6 @@ mod tests {
         let other = BitVector::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(bv, other);
         assert_eq!(size, bytes.len());
+        assert_eq!(size, bv.size_in_bytes());
     }
 }

--- a/src/compact_vector.rs
+++ b/src/compact_vector.rs
@@ -242,8 +242,9 @@ mod tests {
     fn test_serialize() {
         let mut bytes = vec![];
         let cv = CompactVector::from_slice(&gen_random_ints(10000, 42));
-        cv.serialize_into(&mut bytes).unwrap();
+        let size = cv.serialize_into(&mut bytes).unwrap();
         let other = CompactVector::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(cv, other);
+        assert_eq!(size, bytes.len());
     }
 }

--- a/src/compact_vector.rs
+++ b/src/compact_vector.rs
@@ -6,7 +6,7 @@ use std::mem::size_of;
 use anyhow::Result;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::{util::needed_bits, BitVector};
+use crate::{util, BitVector};
 
 /// Compact vector in which each integer is represented in the specified number of bits.
 ///
@@ -88,7 +88,7 @@ impl CompactVector {
     /// ```
     pub fn from_slice(ints: &[usize]) -> Self {
         let &max_int = ints.iter().max().unwrap();
-        let mut cv = Self::with_len(ints.len(), needed_bits(max_int));
+        let mut cv = Self::with_len(ints.len(), util::needed_bits(max_int));
         for (i, &x) in ints.iter().enumerate() {
             cv.set(i, x);
         }
@@ -194,6 +194,10 @@ impl CompactVector {
         let width = reader.read_u64::<LittleEndian>()? as usize;
         Ok(Self { chunks, len, width })
     }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.chunks.size_in_bytes() + (size_of::<u64>() * 2)
+    }
 }
 
 impl std::fmt::Debug for CompactVector {
@@ -246,5 +250,6 @@ mod tests {
         let other = CompactVector::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(cv, other);
         assert_eq!(size, bytes.len());
+        assert_eq!(size, cv.size_in_bytes());
     }
 }

--- a/src/darray.rs
+++ b/src/darray.rs
@@ -384,8 +384,9 @@ mod tests {
     fn test_serialize() {
         let mut bytes = vec![];
         let da = DArray::from_bits(&gen_random_bits(10000, 42));
-        da.serialize_into(&mut bytes).unwrap();
+        let size = da.serialize_into(&mut bytes).unwrap();
         let other = DArray::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(da, other);
+        assert_eq!(size, bytes.len());
     }
 }

--- a/src/elias_fano.rs
+++ b/src/elias_fano.rs
@@ -376,6 +376,20 @@ impl EliasFano {
             universe,
         })
     }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.high_bits.size_in_bytes()
+            + self.high_bits_d1.size_in_bytes()
+            + size_of::<u8>()
+            + if let Some(high_bits_d0) = &self.high_bits_d0 {
+                high_bits_d0.size_in_bytes()
+            } else {
+                0
+            }
+            + self.low_bits.size_in_bytes()
+            + size_of::<u64>()
+            + size_of::<u64>()
+    }
 }
 
 /// Builder of EliasFano.
@@ -585,6 +599,7 @@ mod tests {
         let other = EliasFano::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(ef, other);
         assert_eq!(size, bytes.len());
+        assert_eq!(size, ef.size_in_bytes());
     }
 
     #[test]

--- a/src/elias_fano.rs
+++ b/src/elias_fano.rs
@@ -381,11 +381,10 @@ impl EliasFano {
         self.high_bits.size_in_bytes()
             + self.high_bits_d1.size_in_bytes()
             + size_of::<u8>()
-            + if let Some(high_bits_d0) = &self.high_bits_d0 {
-                high_bits_d0.size_in_bytes()
-            } else {
-                0
-            }
+            + self
+                .high_bits_d0
+                .as_ref()
+                .map_or(0, |high_bits_d0| high_bits_d0.size_in_bytes())
             + self.low_bits.size_in_bytes()
             + size_of::<u64>()
             + size_of::<u64>()

--- a/src/elias_fano.rs
+++ b/src/elias_fano.rs
@@ -11,7 +11,8 @@ use crate::{broadword, darray::DArrayIndex, BitVector};
 /// Compressed monotone increasing sequence through Elias-Fano encoding.
 ///
 /// [`EliasFano`] implements an Elias-Fano representation for monotone increasing sequences.
-/// When a sequence stores $`n`$ integers from $`[0, u-1]`$, this representation takes $`n \lceil \log_2 \frac{u}{n} \rceil + 2n`$ bits of space.
+/// When a sequence stores $`n`$ integers from $`[0, u-1]`$,
+/// this representation takes $`n \lceil \log_2 \frac{u}{n} \rceil + 2n + o(n)`$ bits of space.
 /// That is, a sparse sequence can be stored in a very compressed space.
 ///
 /// This is a yet another Rust port of [succinct::elias_fano](https://github.com/ot/succinct/blob/master/elias_fano.hpp).
@@ -36,6 +37,13 @@ use crate::{broadword, darray::DArrayIndex, BitVector};
 ///
 /// assert_eq!(ef.successor(4), Some(6));
 /// assert_eq!(ef.successor(10), None);
+///
+/// let mut bytes = vec![];
+/// let size = ef.serialize_into(&mut bytes).unwrap();
+/// let other = EliasFano::deserialize_from(&bytes[..]).unwrap();
+/// assert_eq!(ef, other);
+/// assert_eq!(size, bytes.len());
+/// assert_eq!(size, ef.size_in_bytes());
 /// ```
 ///
 /// # References
@@ -159,6 +167,67 @@ impl EliasFano {
             }
         }
         Ok(Self::new(b, with_rank_index))
+    }
+
+    /// Serializes the data structure into the writer,
+    /// returning the number of serialized bytes.
+    ///
+    /// # Arguments
+    ///
+    /// - `writer`: `std::io::Write` variable.
+    pub fn serialize_into<W: Write>(&self, mut writer: W) -> Result<usize> {
+        let mut mem = self.high_bits.serialize_into(&mut writer)?;
+        mem += self.high_bits_d1.serialize_into(&mut writer)?;
+        if let Some(high_bits_d0) = &self.high_bits_d0 {
+            writer.write_u8(1)?;
+            mem += high_bits_d0.serialize_into(&mut writer)?;
+        } else {
+            writer.write_u8(0)?;
+        }
+        mem += self.low_bits.serialize_into(&mut writer)?;
+        writer.write_u64::<LittleEndian>(self.low_len as u64)?;
+        writer.write_u64::<LittleEndian>(self.universe as u64)?;
+        Ok(mem + size_of::<u8>() + size_of::<u64>() + size_of::<u64>())
+    }
+
+    /// Deserializes the data structure from the reader.
+    ///
+    /// # Arguments
+    ///
+    /// - `reader`: `std::io::Read` variable.
+    pub fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
+        let high_bits = BitVector::deserialize_from(&mut reader)?;
+        let high_bits_d1 = DArrayIndex::deserialize_from(&mut reader)?;
+        let high_bits_d0 = if reader.read_u8()? != 0 {
+            Some(DArrayIndex::deserialize_from(&mut reader)?)
+        } else {
+            None
+        };
+        let low_bits = BitVector::deserialize_from(&mut reader)?;
+        let low_len = reader.read_u64::<LittleEndian>()? as usize;
+        let universe = reader.read_u64::<LittleEndian>()? as usize;
+        Ok(Self {
+            high_bits,
+            high_bits_d1,
+            high_bits_d0,
+            low_bits,
+            low_len,
+            universe,
+        })
+    }
+
+    /// Returns the number of bytes to serialize the data structure.
+    pub fn size_in_bytes(&self) -> usize {
+        self.high_bits.size_in_bytes()
+            + self.high_bits_d1.size_in_bytes()
+            + size_of::<u8>()
+            + self
+                .high_bits_d0
+                .as_ref()
+                .map_or(0, |high_bits_d0| high_bits_d0.size_in_bytes())
+            + self.low_bits.size_in_bytes()
+            + size_of::<u64>()
+            + size_of::<u64>()
     }
 
     /// Searches the `k`-th iteger.
@@ -339,55 +408,6 @@ impl EliasFano {
     #[inline(always)]
     pub const fn universe(&self) -> usize {
         self.universe
-    }
-
-    pub fn serialize_into<W: Write>(&self, mut writer: W) -> Result<usize> {
-        let mut mem = self.high_bits.serialize_into(&mut writer)?;
-        mem += self.high_bits_d1.serialize_into(&mut writer)?;
-        if let Some(high_bits_d0) = &self.high_bits_d0 {
-            writer.write_u8(1)?;
-            mem += high_bits_d0.serialize_into(&mut writer)?;
-        } else {
-            writer.write_u8(0)?;
-        }
-        mem += self.low_bits.serialize_into(&mut writer)?;
-        writer.write_u64::<LittleEndian>(self.low_len as u64)?;
-        writer.write_u64::<LittleEndian>(self.universe as u64)?;
-        Ok(mem + size_of::<u8>() + size_of::<u64>() + size_of::<u64>())
-    }
-
-    pub fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
-        let high_bits = BitVector::deserialize_from(&mut reader)?;
-        let high_bits_d1 = DArrayIndex::deserialize_from(&mut reader)?;
-        let high_bits_d0 = if reader.read_u8()? != 0 {
-            Some(DArrayIndex::deserialize_from(&mut reader)?)
-        } else {
-            None
-        };
-        let low_bits = BitVector::deserialize_from(&mut reader)?;
-        let low_len = reader.read_u64::<LittleEndian>()? as usize;
-        let universe = reader.read_u64::<LittleEndian>()? as usize;
-        Ok(Self {
-            high_bits,
-            high_bits_d1,
-            high_bits_d0,
-            low_bits,
-            low_len,
-            universe,
-        })
-    }
-
-    pub fn size_in_bytes(&self) -> usize {
-        self.high_bits.size_in_bytes()
-            + self.high_bits_d1.size_in_bytes()
-            + size_of::<u8>()
-            + self
-                .high_bits_d0
-                .as_ref()
-                .map_or(0, |high_bits_d0| high_bits_d0.size_in_bytes())
-            + self.low_bits.size_in_bytes()
-            + size_of::<u64>()
-            + size_of::<u64>()
     }
 }
 

--- a/src/elias_fano.rs
+++ b/src/elias_fano.rs
@@ -581,9 +581,10 @@ mod tests {
     fn test_serialize() {
         let mut bytes = vec![];
         let ef = EliasFano::from_bits(&gen_random_bits(10000, 42), true).unwrap();
-        ef.serialize_into(&mut bytes).unwrap();
+        let size = ef.serialize_into(&mut bytes).unwrap();
         let other = EliasFano::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(ef, other);
+        assert_eq!(size, bytes.len());
     }
 
     #[test]

--- a/src/elias_fano_list.rs
+++ b/src/elias_fano_list.rs
@@ -106,12 +106,12 @@ impl EliasFanoList {
         self.ef.universe() - 1
     }
 
-    pub fn serialize_into<W: Write>(&self, mut writer: W) -> Result<usize> {
-        self.ef.serialize_into(&mut writer)
+    pub fn serialize_into<W: Write>(&self, writer: W) -> Result<usize> {
+        self.ef.serialize_into(writer)
     }
 
-    pub fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
-        let ef = EliasFano::deserialize_from(&mut reader)?;
+    pub fn deserialize_from<R: Read>(reader: R) -> Result<Self> {
+        let ef = EliasFano::deserialize_from(reader)?;
         Ok(Self { ef })
     }
 }

--- a/src/elias_fano_list.rs
+++ b/src/elias_fano_list.rs
@@ -28,6 +28,13 @@ use crate::{EliasFano, EliasFanoBuilder};
 ///
 /// assert_eq!(list.len(), 4);
 /// assert_eq!(list.sum(), 31);
+///
+/// let mut bytes = vec![];
+/// let size = list.serialize_into(&mut bytes).unwrap();
+/// let other = EliasFanoList::deserialize_from(&bytes[..]).unwrap();
+/// assert_eq!(list, other);
+/// assert_eq!(size, bytes.len());
+/// assert_eq!(size, list.size_in_bytes());
 /// ```
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct EliasFanoList {
@@ -47,6 +54,7 @@ impl EliasFanoList {
     /// use sucds::EliasFanoList;
     ///
     /// let list = EliasFanoList::from_slice(&[5, 14, 2, 10]).unwrap();
+    ///
     /// assert_eq!(list.len(), 4);
     /// assert_eq!(list.sum(), 31);
     /// ```
@@ -64,6 +72,31 @@ impl EliasFanoList {
         Ok(Self {
             ef: EliasFano::new(b, false),
         })
+    }
+
+    /// Serializes the data structure into the writer,
+    /// returning the number of serialized bytes.
+    ///
+    /// # Arguments
+    ///
+    /// - `writer`: `std::io::Write` variable.
+    pub fn serialize_into<W: Write>(&self, writer: W) -> Result<usize> {
+        self.ef.serialize_into(writer)
+    }
+
+    /// Deserializes the data structure from the reader.
+    ///
+    /// # Arguments
+    ///
+    /// - `reader`: `std::io::Read` variable.
+    pub fn deserialize_from<R: Read>(reader: R) -> Result<Self> {
+        let ef = EliasFano::deserialize_from(reader)?;
+        Ok(Self { ef })
+    }
+
+    /// Returns the number of bytes to serialize the data structure.
+    pub fn size_in_bytes(&self) -> usize {
+        self.ef.size_in_bytes()
     }
 
     /// Gets the `i`-th integer.
@@ -105,19 +138,6 @@ impl EliasFanoList {
     pub const fn sum(&self) -> usize {
         self.ef.universe() - 1
     }
-
-    pub fn serialize_into<W: Write>(&self, writer: W) -> Result<usize> {
-        self.ef.serialize_into(writer)
-    }
-
-    pub fn deserialize_from<R: Read>(reader: R) -> Result<Self> {
-        let ef = EliasFano::deserialize_from(reader)?;
-        Ok(Self { ef })
-    }
-
-    pub fn size_in_bytes(&self) -> usize {
-        self.ef.size_in_bytes()
-    }
 }
 
 #[cfg(test)]
@@ -154,11 +174,11 @@ mod tests {
     #[test]
     fn test_serialize() {
         let mut bytes = vec![];
-        let ef = EliasFanoList::from_slice(&gen_random_ints(10000, 42)).unwrap();
-        let size = ef.serialize_into(&mut bytes).unwrap();
+        let list = EliasFanoList::from_slice(&gen_random_ints(10000, 42)).unwrap();
+        let size = list.serialize_into(&mut bytes).unwrap();
         let other = EliasFanoList::deserialize_from(&bytes[..]).unwrap();
-        assert_eq!(ef, other);
+        assert_eq!(list, other);
         assert_eq!(size, bytes.len());
-        assert_eq!(size, ef.size_in_bytes());
+        assert_eq!(size, list.size_in_bytes());
     }
 }

--- a/src/elias_fano_list.rs
+++ b/src/elias_fano_list.rs
@@ -114,6 +114,10 @@ impl EliasFanoList {
         let ef = EliasFano::deserialize_from(reader)?;
         Ok(Self { ef })
     }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.ef.size_in_bytes()
+    }
 }
 
 #[cfg(test)]
@@ -155,5 +159,6 @@ mod tests {
         let other = EliasFanoList::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(ef, other);
         assert_eq!(size, bytes.len());
+        assert_eq!(size, ef.size_in_bytes());
     }
 }

--- a/src/elias_fano_list.rs
+++ b/src/elias_fano_list.rs
@@ -151,8 +151,9 @@ mod tests {
     fn test_serialize() {
         let mut bytes = vec![];
         let ef = EliasFanoList::from_slice(&gen_random_ints(10000, 42)).unwrap();
-        ef.serialize_into(&mut bytes).unwrap();
+        let size = ef.serialize_into(&mut bytes).unwrap();
         let other = EliasFanoList::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(ef, other);
+        assert_eq!(size, bytes.len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,17 +20,6 @@
 //! - [`EliasFanoList`]
 //!   - Compressed integer list through Elias-Fano gap encoding.
 //!
-//! ## Usage
-//!
-//! To use `sucds`, depend on it in your Cargo manifest:
-//!
-//! ```toml
-//! # Cargo.toml
-//!
-//! [dependencies]
-//! sucds = "0.1"
-//! ```
-//!
 //! ## Limitation
 //!
 //! This library is designed to run on 64-bit machines.

--- a/src/rs_bit_vector.rs
+++ b/src/rs_bit_vector.rs
@@ -529,8 +529,9 @@ mod tests {
     fn test_serialize() {
         let mut bytes = vec![];
         let bv = RsBitVector::from_bits(&gen_random_bits(10000, 42), true, true);
-        bv.serialize_into(&mut bytes).unwrap();
+        let size = bv.serialize_into(&mut bytes).unwrap();
         let other = RsBitVector::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(bv, other);
+        assert_eq!(size, bytes.len());
     }
 }

--- a/src/rs_bit_vector.rs
+++ b/src/rs_bit_vector.rs
@@ -3,8 +3,8 @@
 use std::io::{Read, Write};
 use std::mem::size_of;
 
-use anyhow::{anyhow, Result};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use anyhow::Result;
+use byteorder::{ReadBytesExt, WriteBytesExt};
 
 use crate::{broadword, util, BitVector};
 

--- a/src/rs_bit_vector.rs
+++ b/src/rs_bit_vector.rs
@@ -1,7 +1,12 @@
 #![cfg(target_pointer_width = "64")]
 
-use crate::{broadword, BitVector};
-use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+use std::mem::size_of;
+
+use anyhow::{anyhow, Result};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::{broadword, util, BitVector};
 
 const BLOCK_LEN: usize = 8;
 const SELECT_ONES_PER_HINT: usize = 64 * BLOCK_LEN * 2;
@@ -32,7 +37,7 @@ const SELECT_ZEROS_PER_HINT: usize = SELECT_ONES_PER_HINT;
 /// # References
 ///
 ///  - S. Vigna, "Broadword implementation of rank/select queries," In WEA, 2008.
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct RsBitVector {
     bv: BitVector,
     block_rank_pairs: Vec<usize>,
@@ -328,6 +333,45 @@ impl RsBitVector {
         self.len() - self.num_ones()
     }
 
+    pub fn serialize_into<W: Write>(&self, mut writer: W) -> Result<usize> {
+        let mut mem = self.bv.serialize_into(&mut writer)?;
+        mem += util::serialize_int_vector(&self.block_rank_pairs, &mut writer)?;
+        if let Some(select1_hints) = &self.select1_hints {
+            writer.write_u8(1)?;
+            mem += util::serialize_int_vector(&select1_hints, &mut writer)?;
+        } else {
+            writer.write_u8(0)?;
+        }
+        if let Some(select0_hints) = &self.select0_hints {
+            writer.write_u8(1)?;
+            mem += util::serialize_int_vector(&select0_hints, &mut writer)?;
+        } else {
+            writer.write_u8(0)?;
+        }
+        Ok(mem + size_of::<u8>() * 2)
+    }
+
+    pub fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
+        let bv = BitVector::deserialize_from(&mut reader)?;
+        let block_rank_pairs = util::deserialize_int_vector(&mut reader)?;
+        let select1_hints = if reader.read_u8()? != 0 {
+            Some(util::deserialize_int_vector(&mut reader)?)
+        } else {
+            None
+        };
+        let select0_hints = if reader.read_u8()? != 0 {
+            Some(util::deserialize_int_vector(&mut reader)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            bv,
+            block_rank_pairs,
+            select1_hints,
+            select0_hints,
+        })
+    }
+
     #[inline(always)]
     fn num_blocks(&self) -> usize {
         self.block_rank_pairs.len() / 2 - 1
@@ -483,14 +527,10 @@ mod tests {
 
     #[test]
     fn test_serialize() {
-        let bits = gen_random_bits(10000, 42);
-        let bv = RsBitVector::from_bits(&bits, true, true);
-        let bytes = bincode::serialize(&bv).unwrap();
-        let other: RsBitVector = bincode::deserialize(&bytes).unwrap();
-        assert_eq!(bv.len(), other.len());
-        assert_eq!(bv.num_ones(), other.num_ones());
-        assert_eq!(bv.num_zeros(), other.num_zeros());
-        test_rank_select1(&bits, &other);
-        test_rank_select0(&bits, &other);
+        let mut bytes = vec![];
+        let bv = RsBitVector::from_bits(&gen_random_bits(10000, 42), true, true);
+        bv.serialize_into(&mut bytes).unwrap();
+        let other = RsBitVector::deserialize_from(&bytes[..]).unwrap();
+        assert_eq!(bv, other);
     }
 }

--- a/src/rs_bit_vector.rs
+++ b/src/rs_bit_vector.rs
@@ -338,13 +338,13 @@ impl RsBitVector {
         mem += util::int_vector::serialize_into(&self.block_rank_pairs, &mut writer)?;
         if let Some(select1_hints) = &self.select1_hints {
             writer.write_u8(1)?;
-            mem += util::int_vector::serialize_into(&select1_hints, &mut writer)?;
+            mem += util::int_vector::serialize_into(select1_hints, &mut writer)?;
         } else {
             writer.write_u8(0)?;
         }
         if let Some(select0_hints) = &self.select0_hints {
             writer.write_u8(1)?;
-            mem += util::int_vector::serialize_into(&select0_hints, &mut writer)?;
+            mem += util::int_vector::serialize_into(select0_hints, &mut writer)?;
         } else {
             writer.write_u8(0)?;
         }
@@ -376,17 +376,13 @@ impl RsBitVector {
         self.bv.size_in_bytes()
             + util::int_vector::size_in_bytes(&self.block_rank_pairs)
             + size_of::<u8>()
-            + if let Some(select1_hints) = &self.select1_hints {
+            + self.select1_hints.as_ref().map_or(0, |select1_hints| {
                 util::int_vector::size_in_bytes(select1_hints)
-            } else {
-                0
-            }
+            })
             + size_of::<u8>()
-            + if let Some(select0_hints) = &self.select0_hints {
+            + self.select0_hints.as_ref().map_or(0, |select0_hints| {
                 util::int_vector::size_in_bytes(select0_hints)
-            } else {
-                0
-            }
+            })
     }
 
     #[inline(always)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,5 @@
 #![cfg(target_pointer_width = "64")]
 
-use std::io::{Read, Write};
-use std::mem::size_of;
-
-use anyhow::{anyhow, Result};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use num_traits::{FromPrimitive, ToPrimitive};
-
 use crate::broadword;
 
 /// Returns the number of bits to represent `x` at least.
@@ -26,89 +19,111 @@ pub fn needed_bits(x: usize) -> usize {
     broadword::msb(x).map_or(1, |n| n + 1)
 }
 
-/// Serializes the vector of primitive integers into the writer,
-/// returning the number of serialized bytes.
-///
-/// # Arguments
-///
-/// - `vec`: Vector of primitive integers.
-/// - `writer`: Writer.
-pub fn serialize_int_vector<W, T>(vec: &[T], mut writer: W) -> Result<usize>
-where
-    W: Write,
-    T: ToPrimitive,
-{
-    writer.write_u64::<LittleEndian>(vec.len() as u64)?;
-    match size_of::<T>() {
-        1 => {
-            for x in vec {
-                writer.write_u8(x.to_u8().unwrap())?;
-            }
-        }
-        2 => {
-            for x in vec {
-                writer.write_u16::<LittleEndian>(x.to_u16().unwrap())?;
-            }
-        }
-        4 => {
-            for x in vec {
-                writer.write_u32::<LittleEndian>(x.to_u32().unwrap())?;
-            }
-        }
-        8 => {
-            for x in vec {
-                writer.write_u64::<LittleEndian>(x.to_u64().unwrap())?;
-            }
-        }
-        16 => {
-            for x in vec {
-                writer.write_u128::<LittleEndian>(x.to_u128().unwrap())?;
-            }
-        }
-        _ => return Err(anyhow!("Invalid int type.")),
-    }
-    Ok(size_of::<u64>() + (size_of::<T>() * vec.len()))
-}
+/// Utilities for integer vectors.
+pub mod int_vector {
+    use std::io::{Read, Write};
+    use std::mem::size_of;
 
-/// Deserializes the vector of primitive integers from the reader.
-///
-/// # Arguments
-///
-/// - `reader`: Reader.
-pub fn deserialize_int_vector<R, T>(mut reader: R) -> Result<Vec<T>>
-where
-    R: Read,
-    T: FromPrimitive,
-{
-    let len = reader.read_u64::<LittleEndian>()? as usize;
-    let mut vec = Vec::with_capacity(len);
-    match size_of::<T>() {
-        1 => {
-            for _ in 0..len {
-                vec.push(T::from_u8(reader.read_u8()?).unwrap());
+    use anyhow::{anyhow, Result};
+    use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+    use num_traits::{FromPrimitive, ToPrimitive};
+
+    /// Serializes the vector of primitive integers into the writer,
+    /// returning the number of serialized bytes.
+    ///
+    /// # Arguments
+    ///
+    /// - `vec`: Vector of primitive integers.
+    /// - `writer`: Writer.
+    pub fn serialize_into<W, T>(vec: &[T], mut writer: W) -> Result<usize>
+    where
+        W: Write,
+        T: ToPrimitive,
+    {
+        writer.write_u64::<LittleEndian>(vec.len() as u64)?;
+        match size_of::<T>() {
+            1 => {
+                for x in vec {
+                    writer.write_u8(x.to_u8().unwrap())?;
+                }
             }
-        }
-        2 => {
-            for _ in 0..len {
-                vec.push(T::from_u16(reader.read_u16::<LittleEndian>()?).unwrap());
+            2 => {
+                for x in vec {
+                    writer.write_u16::<LittleEndian>(x.to_u16().unwrap())?;
+                }
             }
-        }
-        4 => {
-            for _ in 0..len {
-                vec.push(T::from_u32(reader.read_u32::<LittleEndian>()?).unwrap());
+            4 => {
+                for x in vec {
+                    writer.write_u32::<LittleEndian>(x.to_u32().unwrap())?;
+                }
             }
-        }
-        8 => {
-            for _ in 0..len {
-                vec.push(T::from_u64(reader.read_u64::<LittleEndian>()?).unwrap());
+            8 => {
+                for x in vec {
+                    writer.write_u64::<LittleEndian>(x.to_u64().unwrap())?;
+                }
             }
-        }
-        16 => {
-            for _ in 0..len {
-                vec.push(T::from_u128(reader.read_u128::<LittleEndian>()?).unwrap());
+            16 => {
+                for x in vec {
+                    writer.write_u128::<LittleEndian>(x.to_u128().unwrap())?;
+                }
             }
+            _ => return Err(anyhow!("Invalid int type.")),
         }
-        _ => return Err(anyhow!("Invalid int type.")),
+        Ok(size_of::<u64>() + (size_of::<T>() * vec.len()))
     }
-    Ok(vec)
+
+    /// Deserializes the vector of primitive integers from the reader.
+    ///
+    /// # Arguments
+    ///
+    /// - `reader`: Reader.
+    pub fn deserialize_from<R, T>(mut reader: R) -> Result<Vec<T>>
+    where
+        R: Read,
+        T: FromPrimitive,
+    {
+        let len = reader.read_u64::<LittleEndian>()? as usize;
+        let mut vec = Vec::with_capacity(len);
+        match size_of::<T>() {
+            1 => {
+                for _ in 0..len {
+                    vec.push(T::from_u8(reader.read_u8()?).unwrap());
+                }
+            }
+            2 => {
+                for _ in 0..len {
+                    vec.push(T::from_u16(reader.read_u16::<LittleEndian>()?).unwrap());
+                }
+            }
+            4 => {
+                for _ in 0..len {
+                    vec.push(T::from_u32(reader.read_u32::<LittleEndian>()?).unwrap());
+                }
+            }
+            8 => {
+                for _ in 0..len {
+                    vec.push(T::from_u64(reader.read_u64::<LittleEndian>()?).unwrap());
+                }
+            }
+            16 => {
+                for _ in 0..len {
+                    vec.push(T::from_u128(reader.read_u128::<LittleEndian>()?).unwrap());
+                }
+            }
+            _ => return Err(anyhow!("Invalid int type.")),
+        }
+        Ok(vec)
+    }
+
+    /// Returns the size in bytes when the vector is serialized.
+    ///
+    /// # Arguments
+    ///
+    /// - `vec`: Vector of primitive integers.
+    pub fn size_in_bytes<T>(vec: &[T]) -> usize
+    where
+        T: ToPrimitive,
+    {
+        size_of::<u64>() + (size_of::<T>() * vec.len())
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,12 @@
 #![cfg(target_pointer_width = "64")]
 
+use std::io::{Read, Write};
+use std::mem::size_of;
+
+use anyhow::{anyhow, Result};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use num_traits::{FromPrimitive, ToPrimitive};
+
 use crate::broadword;
 
 /// Returns the number of bits to represent `x` at least.
@@ -17,4 +24,91 @@ use crate::broadword;
 /// ```
 pub fn needed_bits(x: usize) -> usize {
     broadword::msb(x).map_or(1, |n| n + 1)
+}
+
+/// Serializes the vector of primitive integers into the writer,
+/// returning the number of serialized bytes.
+///
+/// # Arguments
+///
+/// - `vec`: Vector of primitive integers.
+/// - `writer`: Writer.
+pub fn serialize_int_vector<W, T>(vec: &[T], mut writer: W) -> Result<usize>
+where
+    W: Write,
+    T: ToPrimitive,
+{
+    writer.write_u64::<LittleEndian>(vec.len() as u64)?;
+    match size_of::<T>() {
+        1 => {
+            for x in vec {
+                writer.write_u8(x.to_u8().unwrap())?;
+            }
+        }
+        2 => {
+            for x in vec {
+                writer.write_u16::<LittleEndian>(x.to_u16().unwrap())?;
+            }
+        }
+        4 => {
+            for x in vec {
+                writer.write_u32::<LittleEndian>(x.to_u32().unwrap())?;
+            }
+        }
+        8 => {
+            for x in vec {
+                writer.write_u64::<LittleEndian>(x.to_u64().unwrap())?;
+            }
+        }
+        16 => {
+            for x in vec {
+                writer.write_u128::<LittleEndian>(x.to_u128().unwrap())?;
+            }
+        }
+        _ => return Err(anyhow!("Invalid int type.")),
+    }
+    Ok(size_of::<u64>() + (size_of::<T>() * vec.len()))
+}
+
+/// Deserializes the vector of primitive integers from the reader.
+///
+/// # Arguments
+///
+/// - `reader`: Reader.
+pub fn deserialize_int_vector<R, T>(mut reader: R) -> Result<Vec<T>>
+where
+    R: Read,
+    T: FromPrimitive,
+{
+    let len = reader.read_u64::<LittleEndian>()? as usize;
+    let mut vec = Vec::with_capacity(len);
+    match size_of::<T>() {
+        1 => {
+            for _ in 0..len {
+                vec.push(T::from_u8(reader.read_u8()?).unwrap());
+            }
+        }
+        2 => {
+            for _ in 0..len {
+                vec.push(T::from_u16(reader.read_u16::<LittleEndian>()?).unwrap());
+            }
+        }
+        4 => {
+            for _ in 0..len {
+                vec.push(T::from_u32(reader.read_u32::<LittleEndian>()?).unwrap());
+            }
+        }
+        8 => {
+            for _ in 0..len {
+                vec.push(T::from_u64(reader.read_u64::<LittleEndian>()?).unwrap());
+            }
+        }
+        16 => {
+            for _ in 0..len {
+                vec.push(T::from_u128(reader.read_u128::<LittleEndian>()?).unwrap());
+            }
+        }
+        _ => return Err(anyhow!("Invalid int type.")),
+    }
+    Ok(vec)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,7 +34,7 @@ pub mod int_vector {
     /// # Arguments
     ///
     /// - `vec`: Vector of primitive integers.
-    /// - `writer`: Writer.
+    /// - `writer`: `std::io::Write` variable.
     pub fn serialize_into<W, T>(vec: &[T], mut writer: W) -> Result<usize>
     where
         W: Write,
@@ -76,7 +76,7 @@ pub mod int_vector {
     ///
     /// # Arguments
     ///
-    /// - `reader`: Reader.
+    /// - `reader`: `std::io::Read` variable.
     pub fn deserialize_from<R, T>(mut reader: R) -> Result<Vec<T>>
     where
         R: Read,
@@ -115,7 +115,7 @@ pub mod int_vector {
         Ok(vec)
     }
 
-    /// Returns the size in bytes when the vector is serialized.
+    /// Returns the number of bytes to serialize the vector.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
In the previous version, the library implements serialization/deserialization with [Serde](https://github.com/serde-rs/serde).

This PR removed the dependency and added some alternative functions.