### PR TITLE
Remove redundant version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,6 @@ For a detailed description of each data structure, please see the [respective do
 - [`WaveletMatrix`](https://docs.rs/sucds/latest/sucds/wavelet_matrix/struct.WaveletMatrix.html)
   - Space-efficient data structure providing myriad operations over integer sequences.
 
-## Usage
-
-To use `sucds`, depend on it in your Cargo manifest:
-
-```toml
-# Cargo.toml
-
-[dependencies]
-sucds = "0.4"
-```
-
 ## Limitation
 
 This library is designed to run on 64-bit machines.

--- a/src/wavelet_matrix.rs
+++ b/src/wavelet_matrix.rs
@@ -127,7 +127,7 @@ impl WaveletMatrix {
     #[inline(always)]
     pub fn get(&self, mut pos: usize) -> usize {
         let mut val = 0;
-        for depth in 0..self.width as usize {
+        for depth in 0..self.width {
             val <<= 1;
             let rsbv = &self.layers[depth];
             if rsbv.get_bit(pos) {
@@ -195,7 +195,7 @@ impl WaveletMatrix {
     pub fn rank_range(&self, range: Range<usize>, val: usize) -> usize {
         let mut start_pos = range.start;
         let mut end_pos = range.end;
-        for depth in 0..self.width as usize {
+        for depth in 0..self.width {
             let bit = Self::get_msb(val, depth, self.width);
             let rsbv = &self.layers[depth];
             if bit {


### PR DESCRIPTION
I often modify the version specification in README after updates. This specification will no longer be necessary.