### PR TITLE
Fix broken 64-bit shift-right no-op

### DIFF
--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -149,7 +149,7 @@ impl CompactVector {
         if !(1..=64).contains(&width) {
             return Err(anyhow!("width must be in 1..=64, but got {width}."));
         }
-        if val >> width != 0 {
+        if width < 64 && val >> width != 0 {
             return Err(anyhow!(
                 "val must fit in width={width} bits, but got {val}."
             ));


### PR DESCRIPTION
`value >> width` is evaluated as `value >> (width % 64)`.
When `width` is 64, this means that `value >> width` is simply `value`, which is not what is intended.

This fixed it by checking `width==64` separately.