### PR TITLE
Add function to return the internal bit vector of CompactVector

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,15 @@ Sucds provides some [succinct data structures](https://en.wikipedia.org/wiki/Suc
 
 https://docs.rs/sucds/
 
-## Limitation
-
-This library is designed to run on 64-bit machines.
-
-## Build docs
-
-The document can be compiled with the following command:
+Or, the document can be compiled with the following command:
 
 ```console
 RUSTDOCFLAGS="--html-in-header katex.html" cargo doc --no-deps
 ```
+
+## Limitation
+
+This library is designed to run on 64-bit machines.
 
 ## Licensing
 

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -409,6 +409,11 @@ impl CompactVector {
     pub const fn width(&self) -> usize {
         self.width
     }
+
+    /// Returns the internal bit vector.
+    pub const fn bit_vector(&self) -> &BitVector {
+        &self.chunks
+    }
 }
 
 impl Build for CompactVector {

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -410,7 +410,10 @@ impl CompactVector {
         self.width
     }
 
-    /// Returns the internal bit vector.
+    /// Returns the internal representation.
+    ///
+    /// Note that this method is for development purposes and
+    /// the returned value may change implicitly in future versions.
     pub const fn bit_vector(&self) -> &BitVector {
         &self.chunks
     }

--- a/src/int_vectors/dacs_opt.rs
+++ b/src/int_vectors/dacs_opt.rs
@@ -64,9 +64,9 @@ impl DacsOpt {
     ///
     /// - `vals`: Slice of integers to be stored.
     /// - `max_levels`: Maximum number of levels. The resulting number of levels is related to
-    ///                 the access time. The smaller this value is, the faster operations can be,
-    ///                 but the larger the memory can be. If [`None`], it computes configuration
-    ///                 without limitation in the number of levels.
+    ///   the access time. The smaller this value is, the faster operations can be,
+    ///   but the larger the memory can be. If [`None`], it computes configuration
+    ///   without limitation in the number of levels.
     ///
     /// # Complexity
     ///


### PR DESCRIPTION
Since CompactVector is primitive, the function to read the internal representation would be useful.

https://github.com/kampersanda/sucds/actions/runs/15381056708/job/43271876375#step:6:35 is also fixed.