### PR TITLE
Make BitVector debug output more compact

### DIFF
--- a/examples/fmt_bit_vector.rs
+++ b/examples/fmt_bit_vector.rs
@@ -11,7 +11,7 @@ fn main() {
     ]);
 
     // Print the BitVector using the default debug format.
-    // The output will be "BitVector { bits: [... 40 items ...], len: 40 }".
+    // The output will be "BitVector { bits: [40 items], len: 40 }".
     println!("{:?}", bv);
 
     // For a more detailed view, use the debug format.

--- a/examples/fmt_bit_vector.rs
+++ b/examples/fmt_bit_vector.rs
@@ -1,0 +1,29 @@
+//! Example to demonstrate the usage of `fmt::Debug` for `BitVector`.
+
+use sucds::bit_vectors::BitVector;
+
+fn main() {
+    let bv = BitVector::from_bits([
+        false, true, false, false, true, false, true, false, false, true, // 10
+        true, false, true, false, false, true, false, true, false, true, // 20
+        false, true, false, true, false, false, true, true, false, true, // 30
+        true, false, true, false, false, true, false, true, false, false, // 40
+    ]);
+
+    // Print the BitVector using the default debug format.
+    // The output will be "BitVector { bits: [... 40 items ...], len: 40 }".
+    println!("{:?}", bv);
+
+    // For a more detailed view, use the debug format.
+    // The output will be:
+    //
+    // BitVector {
+    //     bits: [
+    //         0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+    //         0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0,
+    //         1, 0, 0, 1, 0, 1, 0, 0,
+    //     ],
+    //     len: 40,
+    // }
+    println!("{:#?}", bv);
+}

--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 
 use crate::bit_vectors::prelude::*;
 use crate::broadword;
+use crate::utils::MatrixView;
 use crate::Serializable;
 use unary::UnaryIter;
 
@@ -926,7 +927,7 @@ impl std::fmt::Debug for BitVector {
             *b = self.access(i).unwrap() as u8;
         }
         f.debug_struct("BitVector")
-            .field("bits", &bits)
+            .field("bits", &MatrixView::new(&bits, 32))
             .field("len", &self.len)
             .finish()
     }

--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -927,7 +927,7 @@ impl std::fmt::Debug for BitVector {
             *b = self.access(i).unwrap() as u8;
         }
         f.debug_struct("BitVector")
-            .field("bits", &MatrixView::new(&bits, 32))
+            .field("bits", &MatrixView::new(&bits, 16))
             .field("len", &self.len)
             .finish()
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,7 +75,7 @@ impl<'a, T: std::fmt::Debug> std::fmt::Debug for MatrixView<'a, T> {
             write!(f, "]")
         } else {
             // For a compact view (e.g., `{:?}`), just show a summary
-            write!(f, "[... {} items ...]", self.data.len())
+            write!(f, "[{} items]", self.data.len())
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,3 +37,45 @@ pub fn needed_bits(x: usize) -> usize {
 pub const fn ceiled_divide(x: usize, y: usize) -> usize {
     (x + y - 1) / y
 }
+
+/// A debug view of a matrix-like structure for long arrays.
+pub(crate) struct MatrixView<'a, T> {
+    data: &'a [T],
+    cols: usize,
+}
+
+impl<'a, T> MatrixView<'a, T> {
+    /// Creates a new `MatrixView` from a slice and the number of columns.
+    ///
+    /// # Arguments
+    ///
+    /// - `data`: A slice of data.
+    /// - `cols`: The number of columns in the matrix.
+    pub fn new(data: &'a [T], cols: usize) -> Self {
+        assert!(cols > 0, "Number of columns must be greater than zero.");
+        Self { data, cols }
+    }
+}
+
+impl<'a, T: std::fmt::Debug> std::fmt::Debug for MatrixView<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Use the "pretty" format specifier '#' to decide whether to format nicely
+        if f.alternate() {
+            writeln!(f, "[")?;
+            for row in self.data.chunks(self.cols) {
+                write!(f, "    ")?;
+                for (i, item) in row.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{:?}", item)?;
+                }
+                writeln!(f, ",")?;
+            }
+            write!(f, "]")
+        } else {
+            // For a compact view (e.g., `{:?}`), just show a summary
+            write!(f, "[... {} items ...]", self.data.len())
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ impl<'a, T: std::fmt::Debug> std::fmt::Debug for MatrixView<'a, T> {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:?}", item)?;
+                    write!(f, "{item:?}")?;
                 }
                 writeln!(f, ",")?;
             }


### PR DESCRIPTION
This PR makes `std::fmt::Debug` for `BitVector` more compact, such as:

```rust
println!("{:?}", bv);
// BitVector { bits: [40 items], len: 40 }
```

```rust
println!("{:#?}", bv);
// BitVector {
//     bits: [
//         0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
//         0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0,
//         1, 0, 0, 1, 0, 1, 0, 0,
//     ],
//     len: 40,
// }
```
