### PR TITLE
add BitVector::into_bit_vector and CompactVector::into_words

### DIFF
--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -650,6 +650,11 @@ impl BitVector {
         &self.words
     }
 
+    /// Converts into the slice of raw words.
+    pub fn into_words(self) -> Vec<usize> {
+        self.words
+    }
+
     /// Returns the total number of bits it can hold without reallocating.
     pub fn capacity(&self) -> usize {
         self.words.capacity() * WORD_LEN

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -417,6 +417,14 @@ impl CompactVector {
     pub const fn bit_vector(&self) -> &BitVector {
         &self.chunks
     }
+
+    /// Converts to the internal representation.
+    ///
+    /// Note that this method is for development purposes and
+    /// the returned value may change implicitly in future versions.
+    pub fn into_bit_vector(self) -> BitVector {
+        self.chunks
+    }
 }
 
 impl Build for CompactVector {


### PR DESCRIPTION
Right now if we use CompactVector::bit_vector() and BitVector::words() to implement our own packed integer structure, we need to copy the structures which in case of operating with several GB of data may have a CPU but mostly RAM performance impact.

Here is an example of our code implementing a "Sequence" using sucds to pack the integers:

```rs
    /// Pack the given integers., which have to fit into the given number of bits.
    pub fn new(nums: &[usize], bits_per_entry: usize) -> Sequence {
        use sucds::int_vectors::CompactVector;
        let entries = nums.len();
        let mut cv = CompactVector::with_capacity(nums.len(), bits_per_entry).expect("value too large");
        cv.extend(nums.iter().copied()).unwrap();
        // current API of sucds does not allow moving out the internal data
        let data = cv.bit_vector().words().to_vec();
        Sequence { entries, bits_per_entry, data, crc_handle: None }
    }
}
```

This PR adds two very small functions, BitVector::into_bit_vector and CompactVector::into_words so that we can convert it directly, allowing `let data = cv.into_bit_vector().into_words();` instead.
