### PR TITLE
change usize to u64 in many places that represent values not indexes and reduce error surface

### DIFF
--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -427,7 +427,7 @@ impl BitVector {
     /// assert_eq!(bv.predecessor1(1), Some(1));
     /// assert_eq!(bv.predecessor1(0), None);
     /// ```
-    pub fn predecessor1(&self, pos: usize) -> Option<u64> {
+    pub fn predecessor1(&self, pos: usize) -> Option<usize> {
         if self.len() <= pos {
             return None;
         }
@@ -467,7 +467,7 @@ impl BitVector {
     /// assert_eq!(bv.predecessor0(1), Some(1));
     /// assert_eq!(bv.predecessor0(0), None);
     /// ```
-    pub fn predecessor0(&self, pos: usize) -> Option<u64> {
+    pub fn predecessor0(&self, pos: usize) -> Option<usize> {
         if self.len() <= pos {
             return None;
         }
@@ -507,7 +507,7 @@ impl BitVector {
     /// assert_eq!(bv.successor1(2), Some(2));
     /// assert_eq!(bv.successor1(3), None);
     /// ```
-    pub fn successor1(&self, pos: usize) -> Option<u64> {
+    pub fn successor1(&self, pos: usize) -> Option<usize> {
         if self.len() <= pos {
             return None;
         }
@@ -548,7 +548,7 @@ impl BitVector {
     /// assert_eq!(bv.successor0(2), Some(2));
     /// assert_eq!(bv.successor0(3), None);
     /// ```
-    pub fn successor0(&self, pos: usize) -> Option<u64> {
+    pub fn successor0(&self, pos: usize) -> Option<usize> {
         if self.len() <= pos {
             return None;
         }
@@ -646,12 +646,12 @@ impl BitVector {
     }
 
     /// Gets the slice of raw words.
-    pub fn words(&self) -> &[usize] {
+    pub fn words(&self) -> &[u64] {
         &self.words
     }
 
     /// Converts into the slice of raw words.
-    pub fn into_words(self) -> Vec<usize> {
+    pub fn into_words(self) -> Vec<u64> {
         self.words
     }
 
@@ -768,7 +768,7 @@ impl Rank for BitVector {
     /// assert_eq!(bv.rank1(4), Some(2));
     /// assert_eq!(bv.rank1(5), None);
     /// ```
-    fn rank1(&self, pos: usize) -> Option<u64> {
+    fn rank1(&self, pos: usize) -> Option<usize> {
         if self.len() < pos {
             return None;
         }
@@ -802,7 +802,7 @@ impl Rank for BitVector {
     /// assert_eq!(bv.rank0(4), Some(2));
     /// assert_eq!(bv.rank0(5), None);
     /// ```
-    fn rank0(&self, pos: usize) -> Option<u64> {
+    fn rank0(&self, pos: usize) -> Option<usize> {
         Some(pos - self.rank1(pos)?)
     }
 }
@@ -825,7 +825,7 @@ impl Select for BitVector {
     /// assert_eq!(bv.select1(1), Some(3));
     /// assert_eq!(bv.select1(2), None);
     /// ```
-    fn select1(&self, k: usize) -> Option<u64> {
+    fn select1(&self, k: usize) -> Option<usize> {
         let mut wpos = 0;
         let mut cur_rank = 0;
         while wpos < self.words.len() {
@@ -861,7 +861,7 @@ impl Select for BitVector {
     /// assert_eq!(bv.select0(1), Some(2));
     /// assert_eq!(bv.select0(2), None);
     /// ```
-    fn select0(&self, k: usize) -> Option<u64> {
+    fn select0(&self, k: usize) -> Option<usize> {
         let mut wpos = 0;
         let mut cur_rank = 0;
         while wpos < self.words.len() {
@@ -911,7 +911,7 @@ impl Iterator for Iter<'_> {
     }
 
     #[inline(always)]
-    fn size_hint(&self) -> (usize, Option<u64>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (self.bv.len(), Some(self.bv.len()))
     }
 }
@@ -946,7 +946,7 @@ impl Serializable for BitVector {
     }
 
     fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
-        let words = Vec::<usize>::deserialize_from(&mut reader)?;
+        let words = Vec::<u64>::deserialize_from(&mut reader)?;
         let len = usize::deserialize_from(&mut reader)?;
         Ok(Self { words, len })
     }

--- a/src/bit_vectors/bit_vector.rs
+++ b/src/bit_vectors/bit_vector.rs
@@ -40,7 +40,7 @@ pub const WORD_LEN: usize = std::mem::size_of::<usize>() * 8;
 /// This is a yet another Rust port of [succinct::bit_vector](https://github.com/ot/succinct/blob/master/bit_vector.hpp).
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct BitVector {
-    words: Vec<usize>,
+    words: Vec<u64>,
     len: usize,
 }
 
@@ -99,7 +99,7 @@ impl BitVector {
     /// assert_eq!(bv.get_bit(0), Some(false));
     /// ```
     pub fn from_bit(bit: bool, len: usize) -> Self {
-        let word = if bit { usize::MAX } else { 0 };
+        let word = if bit { u64::MAX } else { 0 };
         let mut words = vec![word; Self::words_for(len)];
         let shift = len % WORD_LEN;
         if shift != 0 {
@@ -193,7 +193,7 @@ impl BitVector {
         let word = pos / WORD_LEN;
         let pos_in_word = pos % WORD_LEN;
         self.words[word] &= !(1 << pos_in_word);
-        self.words[word] |= (bit as usize) << pos_in_word;
+        self.words[word] |= (bit as u64) << pos_in_word;
         Ok(())
     }
 
@@ -217,10 +217,10 @@ impl BitVector {
     pub fn push_bit(&mut self, bit: bool) {
         let pos_in_word = self.len % WORD_LEN;
         if pos_in_word == 0 {
-            self.words.push(bit as usize);
+            self.words.push(bit as u64);
         } else {
             let cur_word = self.words.last_mut().unwrap();
-            *cur_word |= (bit as usize) << pos_in_word;
+            *cur_word |= (bit as u64) << pos_in_word;
         }
         self.len += 1;
     }
@@ -245,7 +245,7 @@ impl BitVector {
     /// assert_eq!(bv.get_bits(2, 3), None);
     /// ```
     #[inline(always)]
-    pub fn get_bits(&self, pos: usize, len: usize) -> Option<usize> {
+    pub fn get_bits(&self, pos: usize, len: usize) -> Option<u64> {
         if WORD_LEN < len || self.len() < pos + len {
             return None;
         }
@@ -257,7 +257,7 @@ impl BitVector {
             if len < WORD_LEN {
                 (1 << len) - 1
             } else {
-                usize::MAX
+                u64::MAX
             }
         };
         let bits = if shift + len <= WORD_LEN {
@@ -301,7 +301,7 @@ impl BitVector {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn set_bits(&mut self, pos: usize, bits: usize, len: usize) -> Result<()> {
+    pub fn set_bits(&mut self, pos: usize, bits: u64, len: usize) -> Result<()> {
         if WORD_LEN < len {
             return Err(anyhow!(
                 "len must be no greater than {WORD_LEN}, but got {len}."
@@ -321,7 +321,7 @@ impl BitVector {
             if len < WORD_LEN {
                 (1 << len) - 1
             } else {
-                usize::MAX
+                u64::MAX
             }
         };
         let bits = bits & mask;
@@ -372,7 +372,7 @@ impl BitVector {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn push_bits(&mut self, bits: usize, len: usize) -> Result<()> {
+    pub fn push_bits(&mut self, bits: u64, len: usize) -> Result<()> {
         if WORD_LEN < len {
             return Err(anyhow!(
                 "len must be no greater than {WORD_LEN}, but got {len}."
@@ -386,7 +386,7 @@ impl BitVector {
             if len < WORD_LEN {
                 (1 << len) - 1
             } else {
-                usize::MAX
+                u64::MAX
             }
         };
         let bits = bits & mask;
@@ -427,7 +427,7 @@ impl BitVector {
     /// assert_eq!(bv.predecessor1(1), Some(1));
     /// assert_eq!(bv.predecessor1(0), None);
     /// ```
-    pub fn predecessor1(&self, pos: usize) -> Option<usize> {
+    pub fn predecessor1(&self, pos: usize) -> Option<u64> {
         if self.len() <= pos {
             return None;
         }
@@ -467,7 +467,7 @@ impl BitVector {
     /// assert_eq!(bv.predecessor0(1), Some(1));
     /// assert_eq!(bv.predecessor0(0), None);
     /// ```
-    pub fn predecessor0(&self, pos: usize) -> Option<usize> {
+    pub fn predecessor0(&self, pos: usize) -> Option<u64> {
         if self.len() <= pos {
             return None;
         }
@@ -507,7 +507,7 @@ impl BitVector {
     /// assert_eq!(bv.successor1(2), Some(2));
     /// assert_eq!(bv.successor1(3), None);
     /// ```
-    pub fn successor1(&self, pos: usize) -> Option<usize> {
+    pub fn successor1(&self, pos: usize) -> Option<u64> {
         if self.len() <= pos {
             return None;
         }
@@ -548,7 +548,7 @@ impl BitVector {
     /// assert_eq!(bv.successor0(2), Some(2));
     /// assert_eq!(bv.successor0(3), None);
     /// ```
-    pub fn successor0(&self, pos: usize) -> Option<usize> {
+    pub fn successor0(&self, pos: usize) -> Option<u64> {
         if self.len() <= pos {
             return None;
         }
@@ -623,7 +623,7 @@ impl BitVector {
     /// assert_eq!(bv.get_bits(1, 64), None);  // out of bounds
     /// ```
     #[inline(always)]
-    pub fn get_word64(&self, pos: usize) -> Option<usize> {
+    pub fn get_word64(&self, pos: usize) -> Option<u64> {
         if self.len <= pos {
             return None;
         }
@@ -768,7 +768,7 @@ impl Rank for BitVector {
     /// assert_eq!(bv.rank1(4), Some(2));
     /// assert_eq!(bv.rank1(5), None);
     /// ```
-    fn rank1(&self, pos: usize) -> Option<usize> {
+    fn rank1(&self, pos: usize) -> Option<u64> {
         if self.len() < pos {
             return None;
         }
@@ -802,7 +802,7 @@ impl Rank for BitVector {
     /// assert_eq!(bv.rank0(4), Some(2));
     /// assert_eq!(bv.rank0(5), None);
     /// ```
-    fn rank0(&self, pos: usize) -> Option<usize> {
+    fn rank0(&self, pos: usize) -> Option<u64> {
         Some(pos - self.rank1(pos)?)
     }
 }
@@ -825,7 +825,7 @@ impl Select for BitVector {
     /// assert_eq!(bv.select1(1), Some(3));
     /// assert_eq!(bv.select1(2), None);
     /// ```
-    fn select1(&self, k: usize) -> Option<usize> {
+    fn select1(&self, k: usize) -> Option<u64> {
         let mut wpos = 0;
         let mut cur_rank = 0;
         while wpos < self.words.len() {
@@ -861,7 +861,7 @@ impl Select for BitVector {
     /// assert_eq!(bv.select0(1), Some(2));
     /// assert_eq!(bv.select0(2), None);
     /// ```
-    fn select0(&self, k: usize) -> Option<usize> {
+    fn select0(&self, k: usize) -> Option<u64> {
         let mut wpos = 0;
         let mut cur_rank = 0;
         while wpos < self.words.len() {
@@ -911,7 +911,7 @@ impl Iterator for Iter<'_> {
     }
 
     #[inline(always)]
-    fn size_hint(&self) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<u64>) {
         (self.bv.len(), Some(self.bv.len()))
     }
 }

--- a/src/bit_vectors/bit_vector/unary.rs
+++ b/src/bit_vectors/bit_vector/unary.rs
@@ -8,13 +8,13 @@ use crate::broadword;
 pub struct UnaryIter<'a> {
     bv: &'a BitVector,
     pos: usize,
-    buf: usize,
+    buf: u64,
 }
 
 impl<'a> UnaryIter<'a> {
     /// Creates the iterator from the given bit position.
     pub fn new(bv: &'a BitVector, pos: usize) -> Self {
-        let buf = bv.words()[pos / WORD_LEN] & (usize::MAX.wrapping_shl((pos % WORD_LEN) as u32));
+        let buf = bv.words()[pos / WORD_LEN] & (u64::MAX.wrapping_shl((pos % WORD_LEN) as u32));
         Self { bv, pos, buf }
     }
 
@@ -57,7 +57,7 @@ impl<'a> UnaryIter<'a> {
         }
         debug_assert!(buf != 0);
         let pos_in_word = broadword::select_in_word(buf, k - skipped).unwrap();
-        self.buf = buf & usize::MAX.wrapping_shl(pos_in_word as u32);
+        self.buf = buf & u64::MAX.wrapping_shl(pos_in_word as u32);
         self.pos = (self.pos & !(WORD_LEN - 1)) + pos_in_word;
         Some(self.pos)
     }
@@ -80,7 +80,7 @@ impl<'a> UnaryIter<'a> {
     pub fn skip0(&mut self, k: usize) -> Option<usize> {
         let mut skipped = 0;
         let pos_in_word = self.pos % WORD_LEN;
-        let mut buf = !self.buf & usize::MAX.wrapping_shl(pos_in_word as u32);
+        let mut buf = !self.buf & u64::MAX.wrapping_shl(pos_in_word as u32);
         loop {
             let w = broadword::popcount(buf);
             if skipped + w > k {
@@ -96,7 +96,7 @@ impl<'a> UnaryIter<'a> {
         }
         debug_assert!(buf != 0);
         let pos_in_word = broadword::select_in_word(buf, k - skipped).unwrap();
-        self.buf = !buf & usize::MAX.wrapping_shl(pos_in_word as u32);
+        self.buf = !buf & u64::MAX.wrapping_shl(pos_in_word as u32);
         self.pos = (self.pos & !(WORD_LEN - 1)) + pos_in_word;
         Some(self.pos).filter(|&x| x < self.bv.num_bits())
     }

--- a/src/bit_vectors/darray/inner.rs
+++ b/src/bit_vectors/darray/inner.rs
@@ -110,7 +110,7 @@ impl DArrayIndex {
 
             let mut word_idx = start_pos / 64;
             let word_shift = start_pos % 64;
-            let mut word = w(bv, word_idx) & (usize::MAX << word_shift);
+            let mut word = w(bv, word_idx) & (u64::MAX << word_shift);
 
             loop {
                 let popcnt = broadword::popcount(word);
@@ -222,11 +222,11 @@ impl DArrayIndex {
         cur_block_positions.clear();
     }
 
-    fn get_word_over_one(bv: &BitVector, word_idx: usize) -> usize {
+    fn get_word_over_one(bv: &BitVector, word_idx: usize) -> u64 {
         bv.words()[word_idx]
     }
 
-    fn get_word_over_zero(bv: &BitVector, word_idx: usize) -> usize {
+    fn get_word_over_zero(bv: &BitVector, word_idx: usize) -> u64 {
         !bv.words()[word_idx]
     }
 }

--- a/src/bit_vectors/sarray.rs
+++ b/src/bit_vectors/sarray.rs
@@ -67,7 +67,7 @@ impl SArray {
         let num_ones =
             (0..bv.num_words()).fold(0, |acc, i| acc + broadword::popcount(bv.words()[i]));
         let ef = if num_ones != 0 {
-            let mut b = EliasFanoBuilder::new(num_bits, num_ones).unwrap();
+            let mut b = EliasFanoBuilder::new(num_bits, num_ones);
             for i in bv.unary_iter(0) {
                 b.push(i).unwrap();
             }

--- a/src/bit_vectors/sarray.rs
+++ b/src/bit_vectors/sarray.rs
@@ -67,9 +67,9 @@ impl SArray {
         let num_ones =
             (0..bv.num_words()).fold(0, |acc, i| acc + broadword::popcount(bv.words()[i]));
         let ef = if num_ones != 0 {
-            let mut b = EliasFanoBuilder::new(num_bits, num_ones);
+            let mut b = EliasFanoBuilder::new(num_bits as u64, num_ones);
             for i in bv.unary_iter(0) {
-                b.push(i).unwrap();
+                b.push(i as u64).unwrap();
             }
             Some(b.build())
         } else {
@@ -253,7 +253,7 @@ impl Access for SArray {
         }
         self.ef
             .as_ref()
-            .map_or(Some(false), |ef| Some(ef.binsearch(pos).is_some()))
+            .map_or(Some(false), |ef| Some(ef.binsearch(pos as u64).is_some()))
     }
 }
 

--- a/src/broadword.rs
+++ b/src/broadword.rs
@@ -145,7 +145,7 @@ pub fn lsb(x: usize) -> Option<usize> {
 /// ```
 #[allow(clippy::missing_const_for_fn)]
 #[inline(always)]
-pub fn msb(x: usize) -> Option<usize> {
+pub fn msb(x: u64) -> Option<u64> {
     #[cfg(not(feature = "intrinsics"))]
     {
         if x == 0 {

--- a/src/broadword.rs
+++ b/src/broadword.rs
@@ -51,7 +51,7 @@ pub(crate) const fn bytes_sum(x: u64) -> usize {
 /// use sucds::broadword::popcount;
 ///
 /// assert_eq!(popcount(0), 0);
-/// assert_eq!(popcount(usize::MAX), 64);
+/// assert_eq!(popcount(u64::MAX), 64);
 /// assert_eq!(popcount(0b1010110011), 6);
 /// ```
 #[inline(always)]

--- a/src/broadword.rs
+++ b/src/broadword.rs
@@ -90,7 +90,7 @@ pub const fn select_in_word(x: u64, k: usize) -> Option<usize> {
     let place = {
         #[cfg(feature = "intrinsics")]
         {
-            popcount(geq_k_step_8) * 8
+            popcount(geq_k_step_8 as u64) * 8
         }
         #[cfg(not(feature = "intrinsics"))]
         {

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -40,7 +40,7 @@ use crate::Serializable;
 /// assert_eq!(wm.alph_size(), 'n' as usize + 1);
 /// assert_eq!(wm.alph_width(), 7);
 ///
-/// assert_eq!(wm.access(2), Some('n' as usize));
+/// assert_eq!(wm.access(2), Some('n' as usize ));
 /// assert_eq!(wm.rank(3, 'a' as usize), Some(1));
 /// assert_eq!(wm.select(1, 'n' as usize), Some(4));
 /// # Ok(())
@@ -57,7 +57,7 @@ use crate::Serializable;
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct WaveletMatrix<B> {
     layers: Vec<B>,
-    alph_size: usize,
+    alph_size: u64,
 }
 
 impl<B> WaveletMatrix<B>
@@ -552,7 +552,7 @@ where
 
     /// Returns the maximum value + 1 in the sequence, i.e., $`\sigma`$.
     #[inline(always)]
-    pub const fn alph_size(&self) -> usize {
+    pub const fn alph_size(&self) -> u64 {
         self.alph_size
     }
 
@@ -612,7 +612,7 @@ where
 
     fn deserialize_from<R: Read>(mut reader: R) -> Result<Self> {
         let layers = Vec::<B>::deserialize_from(&mut reader)?;
-        let alph_size = usize::deserialize_from(&mut reader)?;
+        let alph_size = u64::deserialize_from(&mut reader)?;
         Ok(Self { layers, alph_size })
     }
 

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -40,9 +40,9 @@ use crate::Serializable;
 /// assert_eq!(wm.alph_size(), 'n' as u64 + 1);
 /// assert_eq!(wm.alph_width(), 7);
 ///
-/// assert_eq!(wm.access(2), Some('n' as u64));
-/// assert_eq!(wm.rank(3, 'a' as u64), Some(1));
-/// assert_eq!(wm.select(1, 'n' as u64), Some(4));
+/// assert_eq!(wm.access(2), Some('n' as usize));
+/// assert_eq!(wm.rank(3, 'a' as usize), Some(1));
+/// assert_eq!(wm.select(1, 'n' as usize), Some(4));
 /// # Ok(())
 /// # }
 /// ```
@@ -150,8 +150,8 @@ where
     /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.access(2), Some('n' as u64));
-    /// assert_eq!(wm.access(5), Some('a' as u64));
+    /// assert_eq!(wm.access(2), Some('n' as usize));
+    /// assert_eq!(wm.access(5), Some('a' as usize));
     /// assert_eq!(wm.access(6), None);
     /// # Ok(())
     /// # }
@@ -200,9 +200,9 @@ where
     /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.rank(3, 'a' as u64), Some(1));
-    /// assert_eq!(wm.rank(5, 'c' as u64), Some(0));
-    /// assert_eq!(wm.rank(7, 'b' as u64), None);
+    /// assert_eq!(wm.rank(3, 'a' as usize), Some(1));
+    /// assert_eq!(wm.rank(5, 'c' as usize), Some(0));
+    /// assert_eq!(wm.rank(7, 'b' as usize), None);
     /// # Ok(())
     /// # }
     /// ```
@@ -235,9 +235,9 @@ where
     /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.rank_range(1..4, 'a' as u64), Some(2));
-    /// assert_eq!(wm.rank_range(2..4, 'c' as u64), Some(0));
-    /// assert_eq!(wm.rank_range(4..7, 'b' as u64), None);
+    /// assert_eq!(wm.rank_range(1..4, 'a' as usize), Some(2));
+    /// assert_eq!(wm.rank_range(2..4, 'c' as usize), Some(0));
+    /// assert_eq!(wm.rank_range(4..7, 'b' as usize), None);
     /// # Ok(())
     /// # }
     /// ```
@@ -291,8 +291,8 @@ where
     /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.select(1, 'a' as u64), Some(3));
-    /// assert_eq!(wm.select(0, 'c' as u64), None);
+    /// assert_eq!(wm.select(1, 'a' as usize), Some(3));
+    /// assert_eq!(wm.select(0, 'c' as usize), None);
     /// # Ok(())
     /// # }
     /// ```
@@ -423,15 +423,15 @@ where
     /// // Intersections among "ana", "na", and "ba".
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 0),
-    ///     Some(vec!['a' as u64, 'b' as u64, 'n' as u64])
+    ///     Some(vec!['a' as usize, 'b' as usize, 'n' as usize])
     /// );
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 1),
-    ///     Some(vec!['a' as u64, 'n' as u64])
+    ///     Some(vec!['a' as usize, 'n' as usize])
     /// );
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 2),
-    ///     Some(vec!['a' as u64])
+    ///     Some(vec!['a' as usize])
     /// );
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 3),
@@ -527,9 +527,9 @@ where
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
     /// let mut it = wm.iter();
-    /// assert_eq!(it.next(), Some('b' as u64));
-    /// assert_eq!(it.next(), Some('a' as u64));
-    /// assert_eq!(it.next(), Some('n' as u64));
+    /// assert_eq!(it.next(), Some('b' as usize));
+    /// assert_eq!(it.next(), Some('a' as usize));
+    /// assert_eq!(it.next(), Some('n' as usize));
     /// assert_eq!(it.next(), None);
     /// # Ok(())
     /// # }

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -33,16 +33,16 @@ use crate::Serializable;
 ///
 /// // It accepts an integer representable in 8 bits.
 /// let mut seq = CompactVector::new(8)?;
-/// seq.extend(text.chars().map(|c| c as usize))?;
+/// seq.extend(text.chars().map(|c| c as u64 ))?;
 /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
 ///
 /// assert_eq!(wm.len(), len);
-/// assert_eq!(wm.alph_size(), 'n' as usize + 1);
+/// assert_eq!(wm.alph_size(), 'n' as u64 + 1);
 /// assert_eq!(wm.alph_width(), 7);
 ///
-/// assert_eq!(wm.access(2), Some('n' as usize ));
-/// assert_eq!(wm.rank(3, 'a' as usize), Some(1));
-/// assert_eq!(wm.select(1, 'n' as usize), Some(4));
+/// assert_eq!(wm.access(2), Some('n' as u64));
+/// assert_eq!(wm.rank(3, 'a' as u64), Some(1));
+/// assert_eq!(wm.select(1, 'n' as u64), Some(4));
 /// # Ok(())
 /// # }
 /// ```
@@ -78,7 +78,7 @@ where
         }
 
         let alph_size = seq.iter().max().unwrap() + 1;
-        let alph_width = utils::needed_bits(alph_size);
+        let alph_width = utils::needed_bits(alph_size as u64);
 
         let mut zeros = seq;
         let mut ones = CompactVector::new(alph_width).unwrap();
@@ -147,11 +147,11 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("banana".chars().map(|c| c as usize))?;
+    /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.access(2), Some('n' as usize));
-    /// assert_eq!(wm.access(5), Some('a' as usize));
+    /// assert_eq!(wm.access(2), Some('n' as u64));
+    /// assert_eq!(wm.access(5), Some('a' as u64));
     /// assert_eq!(wm.access(6), None);
     /// # Ok(())
     /// # }
@@ -197,12 +197,12 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("banana".chars().map(|c| c as usize))?;
+    /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.rank(3, 'a' as usize), Some(1));
-    /// assert_eq!(wm.rank(5, 'c' as usize), Some(0));
-    /// assert_eq!(wm.rank(7, 'b' as usize), None);
+    /// assert_eq!(wm.rank(3, 'a' as u64), Some(1));
+    /// assert_eq!(wm.rank(5, 'c' as u64), Some(0));
+    /// assert_eq!(wm.rank(7, 'b' as u64), None);
     /// # Ok(())
     /// # }
     /// ```
@@ -232,12 +232,12 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("banana".chars().map(|c| c as usize))?;
+    /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.rank_range(1..4, 'a' as usize), Some(2));
-    /// assert_eq!(wm.rank_range(2..4, 'c' as usize), Some(0));
-    /// assert_eq!(wm.rank_range(4..7, 'b' as usize), None);
+    /// assert_eq!(wm.rank_range(1..4, 'a' as u64), Some(2));
+    /// assert_eq!(wm.rank_range(2..4, 'c' as u64), Some(0));
+    /// assert_eq!(wm.rank_range(4..7, 'b' as u64), None);
     /// # Ok(())
     /// # }
     /// ```
@@ -288,11 +288,11 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("banana".chars().map(|c| c as usize))?;
+    /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
-    /// assert_eq!(wm.select(1, 'a' as usize), Some(3));
-    /// assert_eq!(wm.select(0, 'c' as usize), None);
+    /// assert_eq!(wm.select(1, 'a' as u64), Some(3));
+    /// assert_eq!(wm.select(0, 'c' as u64), None);
     /// # Ok(())
     /// # }
     /// ```
@@ -349,7 +349,7 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("banana".chars().map(|c| c as usize))?;
+    /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
     /// assert_eq!(wm.quantile(1..4, 0), Some('a' as usize)); // The 0th in "ana" should be "a"
@@ -417,21 +417,21 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("banana".chars().map(|c| c as usize))?;
+    /// seq.extend("banana".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
     /// // Intersections among "ana", "na", and "ba".
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 0),
-    ///     Some(vec!['a' as usize, 'b' as usize, 'n' as usize])
+    ///     Some(vec!['a' as u64, 'b' as u64, 'n' as u64])
     /// );
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 1),
-    ///     Some(vec!['a' as usize, 'n' as usize])
+    ///     Some(vec!['a' as u64, 'n' as u64])
     /// );
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 2),
-    ///     Some(vec!['a' as usize])
+    ///     Some(vec!['a' as u64])
     /// );
     /// assert_eq!(
     ///     wm.intersect(&[1..4, 4..6, 0..2], 3),
@@ -523,13 +523,13 @@ where
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut seq = CompactVector::new(8)?;
-    /// seq.extend("ban".chars().map(|c| c as usize))?;
+    /// seq.extend("ban".chars().map(|c| c as u64))?;
     /// let wm = WaveletMatrix::<Rank9Sel>::new(seq)?;
     ///
     /// let mut it = wm.iter();
-    /// assert_eq!(it.next(), Some('b' as usize));
-    /// assert_eq!(it.next(), Some('a' as usize));
-    /// assert_eq!(it.next(), Some('n' as usize));
+    /// assert_eq!(it.next(), Some('b' as u64));
+    /// assert_eq!(it.next(), Some('a' as u64));
+    /// assert_eq!(it.next(), Some('n' as u64));
     /// assert_eq!(it.next(), None);
     /// # Ok(())
     /// # }
@@ -643,11 +643,11 @@ mod test {
         let len = text.chars().count();
 
         let mut seq = CompactVector::new(8).unwrap();
-        seq.extend(text.chars().map(|c| c as usize)).unwrap();
+        seq.extend(text.chars().map(|c| c as u64)).unwrap();
         let wm = WaveletMatrix::<Rank9Sel>::new(seq).unwrap();
 
         assert_eq!(wm.len(), len);
-        assert_eq!(wm.alph_size(), ('u' as usize) + 1);
+        assert_eq!(wm.alph_size(), ('u' as u64) + 1);
         assert_eq!(wm.alph_width(), 7);
 
         assert_eq!(wm.access(20), Some('h' as usize));
@@ -667,7 +667,7 @@ mod test {
     fn test_serialize() {
         let text = "tobeornottobethatisthequestion";
         let mut seq = CompactVector::new(8).unwrap();
-        seq.extend(text.chars().map(|c| c as usize)).unwrap();
+        seq.extend(text.chars().map(|c| c as u64)).unwrap();
         let wm = WaveletMatrix::<Rank9Sel>::new(seq).unwrap();
 
         let mut bytes = vec![];

--- a/src/char_sequences/wavelet_matrix.rs
+++ b/src/char_sequences/wavelet_matrix.rs
@@ -78,7 +78,7 @@ where
         }
 
         let alph_size = seq.iter().max().unwrap() + 1;
-        let alph_width = utils::needed_bits(alph_size as u64);
+        let alph_width = utils::needed_bits(alph_size);
 
         let mut zeros = seq;
         let mut ones = CompactVector::new(alph_width).unwrap();

--- a/src/int_vectors.rs
+++ b/src/int_vectors.rs
@@ -98,7 +98,7 @@ pub trait Build {
     ///
     fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
         Self: Sized;
 }
 

--- a/src/int_vectors.rs
+++ b/src/int_vectors.rs
@@ -88,9 +88,6 @@ pub use dacs_byte::DacsByte;
 pub use dacs_opt::DacsOpt;
 pub use prefix_summed_elias_fano::PrefixSummedEliasFano;
 
-use anyhow::Result;
-use num_traits::ToPrimitive;
-
 /// Interface for building integer vectors.
 pub trait Build {
     /// Creates a new vector from a slice of integers `vals`.
@@ -99,12 +96,9 @@ pub trait Build {
     ///
     ///  - `vals`: Slice of integers to be stored.
     ///
-    /// # Errors
-    ///
-    /// An error is returned if `vals` contains an integer that cannot be cast to [`usize`].
-    fn build_from_slice<T>(vals: &[T]) -> Result<Self>
+    fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: ToPrimitive,
+        T: Into<usize> + Copy,
         Self: Sized;
 }
 

--- a/src/int_vectors.rs
+++ b/src/int_vectors.rs
@@ -111,5 +111,5 @@ pub trait NumVals {
 /// Interface for accessing elements on integer vectors.
 pub trait Access {
     /// Returns the `pos`-th integer, or [`None`] if out of bounds.
-    fn access(&self, pos: usize) -> Option<usize>;
+    fn access(&self, pos: usize) -> Option<u64>;
 }

--- a/src/int_vectors.rs
+++ b/src/int_vectors.rs
@@ -68,7 +68,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use sucds::int_vectors::{DacsOpt, prelude::*};
 //!
-//! let seq = DacsOpt::build_from_slice(&[5, 0, 100000, 334])?;
+//! let seq = DacsOpt::build_from_slice(&[5u64, 0, 100000, 334]);
 //!
 //! assert_eq!(seq.num_vals(), 4);
 //!

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -193,10 +193,10 @@ impl CompactVector {
         for x in vals {
             max_int = max_int.max((*x).into());
         }
-        // unwrap should be safe
+        // unwraps should be safe
         let mut cv = Self::with_capacity(vals.len(), utils::needed_bits(max_int)).unwrap();
         for x in vals {
-            cv.push_int((*x).into());
+            cv.push_int((*x).into()).unwrap();
         }
         cv
     }

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -225,7 +225,7 @@ impl CompactVector {
     /// assert_eq!(cv.get_int(3), None);
     /// # Ok(())
     /// # }
-    pub fn get_int(&self, pos: usize) -> Option<usize> {
+    pub fn get_int(&self, pos: usize) -> Option<u64> {
         self.chunks.get_bits(pos * self.width, self.width)
     }
 
@@ -260,7 +260,7 @@ impl CompactVector {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn set_int(&mut self, pos: usize, val: usize) -> Result<()> {
+    pub fn set_int(&mut self, pos: usize, val: u64) -> Result<()> {
         if self.len() <= pos {
             return Err(anyhow!(
                 "pos must be no greater than self.len()={}, but got {pos}.",
@@ -464,7 +464,7 @@ impl Access for CompactVector {
     /// assert_eq!(cv.access(3), None);
     /// # Ok(())
     /// # }
-    fn access(&self, pos: usize) -> Option<usize> {
+    fn access(&self, pos: usize) -> Option<u64> {
         self.get_int(pos)
     }
 }
@@ -661,7 +661,7 @@ mod tests {
     #[test]
     fn test_serialize() {
         let mut bytes = vec![];
-        let cv = CompactVector::from_slice(&[7usize, 334, 1, 2]);
+        let cv = CompactVector::from_slice(&[7u64, 334, 1, 2]);
         let size = cv.serialize_into(&mut bytes).unwrap();
         let other = CompactVector::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(cv, other);

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -144,7 +144,7 @@ impl CompactVector {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_int(val: usize, len: usize, width: usize) -> Result<Self> {
+    pub fn from_int(val: u64, len: usize, width: usize) -> Result<Self> {
         if !(1..=64).contains(&width) {
             return Err(anyhow!("width must be in 1..=64, but got {width}."));
         }
@@ -170,10 +170,6 @@ impl CompactVector {
     ///
     ///  - `vals`: Slice of integers to be stored.
     ///
-    /// # Errors
-    ///
-    /// An error is returned if `vals` contains an integer that cannot be cast to [`usize`].
-    ///
     /// # Examples
     ///
     /// ```
@@ -189,12 +185,12 @@ impl CompactVector {
     /// ```
     pub fn from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
     {
         if vals.is_empty() {
             return Self::default();
         }
-        let mut max_int: usize = 1;
+        let mut max_int = 0u64;
         for x in vals {
             max_int = max_int.max((*x).into());
         }
@@ -312,7 +308,7 @@ impl CompactVector {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn push_int(&mut self, val: usize) -> Result<()> {
+    pub fn push_int(&mut self, val: u64) -> Result<()> {
         if self.width() != 64 && val >> self.width() != 0 {
             return Err(anyhow!(
                 "val must fit in self.width()={} bits, but got {val}.",
@@ -353,7 +349,7 @@ impl CompactVector {
     /// ```
     pub fn extend<I>(&mut self, vals: I) -> Result<()>
     where
-        I: IntoIterator<Item = usize>,
+        I: IntoIterator<Item = u64>,
     {
         for x in vals {
             self.push_int(x)?;
@@ -429,7 +425,7 @@ impl Build for CompactVector {
     /// This just calls [`Self::from_slice()`]. See the documentation.
     fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
         Self: Sized,
     {
         Self::from_slice(vals)
@@ -487,7 +483,7 @@ impl<'a> Iter<'a> {
 }
 
 impl Iterator for Iter<'_> {
-    type Item = usize;
+    type Item = u64;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -24,13 +24,13 @@ use crate::{utils, Serializable};
 /// // Can store integers within 3 bits each.
 /// let mut cv = CompactVector::new(3)?;
 ///
-/// cv.push_int(7)?;
-/// cv.push_int(2)?;
+/// cv.push_int(7);
+/// cv.push_int(2);
 ///
 /// assert_eq!(cv.len(), 2);
 /// assert_eq!(cv.get_int(0), Some(7));
 ///
-/// cv.set_int(0, 5)?;
+/// cv.set_int(0, 5);
 /// assert_eq!(cv.get_int(0), Some(5));
 /// # Ok(())
 /// # }
@@ -176,11 +176,10 @@ impl CompactVector {
     /// # fn main() {
     /// use sucds::int_vectors::CompactVector;
     ///
-    /// let mut cv = CompactVector::from_slice(&[7, 2]);
+    /// let mut cv = CompactVector::from_slice(&[7u64, 2]);
     /// assert_eq!(cv.len(), 2);
     /// assert_eq!(cv.width(), 3);
     /// assert_eq!(cv.get_int(0), Some(7));
-    /// # Ok(())
     /// # }
     /// ```
     pub fn from_slice<T>(vals: &[T]) -> Self
@@ -218,7 +217,7 @@ impl CompactVector {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::CompactVector;
     ///
-    /// let cv = CompactVector::from_slice(&[5, 256, 0])?;
+    /// let cv = CompactVector::from_slice(&[5u64, 256, 0]);
     /// assert_eq!(cv.get_int(0), Some(5));
     /// assert_eq!(cv.get_int(1), Some(256));
     /// assert_eq!(cv.get_int(2), Some(0));
@@ -254,7 +253,7 @@ impl CompactVector {
     /// use sucds::int_vectors::CompactVector;
     ///
     /// let mut cv = CompactVector::from_int(0, 2, 3)?;
-    /// cv.set_int(1, 4)?;
+    /// cv.set_int(1, 4);
     /// assert_eq!(cv.get_int(1), Some(4));
     /// # Ok(())
     /// # }
@@ -365,7 +364,7 @@ impl CompactVector {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::CompactVector;
     ///
-    /// let cv = CompactVector::from_slice(&[5, 256, 0])?;
+    /// let cv = CompactVector::from_slice(&[5u64, 256, 0]);
     /// let mut it = cv.iter();
     ///
     /// assert_eq!(it.next(), Some(5));
@@ -457,7 +456,7 @@ impl Access for CompactVector {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::{CompactVector, Access};
     ///
-    /// let cv = CompactVector::from_slice(&[5, 256, 0])?;
+    /// let cv = CompactVector::from_slice(&[5u64, 256, 0]);
     /// assert_eq!(cv.access(0), Some(5));
     /// assert_eq!(cv.access(1), Some(256));
     /// assert_eq!(cv.access(2), Some(0));

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -30,7 +30,7 @@ use crate::{utils, Serializable};
 /// assert_eq!(cv.len(), 2);
 /// assert_eq!(cv.get_int(0), Some(7));
 ///
-/// cv.set_int(0, 5);
+/// cv.set_int(0, 5)?;
 /// assert_eq!(cv.get_int(0), Some(5));
 /// # Ok(())
 /// # }

--- a/src/int_vectors/compact_vector.rs
+++ b/src/int_vectors/compact_vector.rs
@@ -24,8 +24,8 @@ use crate::{utils, Serializable};
 /// // Can store integers within 3 bits each.
 /// let mut cv = CompactVector::new(3)?;
 ///
-/// cv.push_int(7);
-/// cv.push_int(2);
+/// cv.push_int(7)?;
+/// cv.push_int(2)?;
 ///
 /// assert_eq!(cv.len(), 2);
 /// assert_eq!(cv.get_int(0), Some(7));

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -4,8 +4,7 @@
 use std::convert::TryFrom;
 use std::io::{Read, Write};
 
-use anyhow::{anyhow, Result};
-use num_traits::ToPrimitive;
+use anyhow::Result;
 
 use crate::bit_vectors::{self, BitVector, Rank, Rank9Sel};
 use crate::int_vectors::{Access, Build, NumVals};
@@ -65,44 +64,38 @@ impl DacsByte {
     ///
     /// - `vals`: Slice of integers to be stored.
     ///
-    /// # Errors
-    ///
-    /// An error is returned if `vals` contains an integer that cannot be cast to [`usize`].
-    pub fn from_slice<T>(vals: &[T]) -> Result<Self>
+    pub fn from_slice<T>(vals: &[T]) -> Self
     where
-        T: ToPrimitive,
+        T: Into<usize> + Copy,
     {
         if vals.is_empty() {
-            return Ok(Self::default());
+            return Self::default();
         }
 
         let mut maxv = 0;
         for x in vals {
-            maxv =
-                maxv.max(x.to_usize().ok_or_else(|| {
-                    anyhow!("vals must consist only of values castable into usize.")
-                })?);
+            maxv = maxv.max((*x).into());
         }
-        let num_bits = utils::needed_bits(maxv);
+        let num_bits = utils::needed_bits(maxv.into());
         let num_levels = utils::ceiled_divide(num_bits, LEVEL_WIDTH);
         assert_ne!(num_levels, 0);
 
         if num_levels == 1 {
             let data: Vec<_> = vals
                 .iter()
-                .map(|x| u8::try_from(x.to_usize().unwrap()).unwrap())
+                .map(|x| u8::try_from((*x).into()).unwrap())
                 .collect();
-            return Ok(Self {
+            return Self {
                 data: vec![data],
                 flags: vec![],
-            });
+            };
         }
 
         let mut data = vec![vec![]; num_levels];
         let mut flags = vec![BitVector::default(); num_levels - 1];
 
         for x in vals {
-            let mut x = x.to_usize().unwrap();
+            let mut x = (*x).into();
             for j in 0..num_levels {
                 data[j].push(u8::try_from(x & LEVEL_MASK).unwrap());
                 x >>= LEVEL_WIDTH;
@@ -118,7 +111,7 @@ impl DacsByte {
         }
 
         let flags = flags.into_iter().map(Rank9Sel::new).collect();
-        Ok(Self { data, flags })
+        Self { data, flags }
     }
 
     /// Creates an iterator for enumerating integers.
@@ -183,9 +176,9 @@ impl Build for DacsByte {
     /// Creates a new vector from a slice of integers `vals`.
     ///
     /// This just calls [`Self::from_slice()`]. See the documentation.
-    fn build_from_slice<T>(vals: &[T]) -> Result<Self>
+    fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: ToPrimitive,
+        T: Into<usize> + Copy,
         Self: Sized,
     {
         Self::from_slice(vals)
@@ -213,7 +206,7 @@ impl Access for DacsByte {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::{DacsByte, Access};
     ///
-    /// let seq = DacsByte::from_slice(&[5, 999, 334])?;
+    /// let seq = DacsByte::from_slice(&[5, 999, 334]);
     ///
     /// assert_eq!(seq.access(0), Some(5));
     /// assert_eq!(seq.access(1), Some(999));
@@ -298,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_basic() {
-        let seq = DacsByte::from_slice(&[0xFFFF, 0xFF, 0xF, 0xFFFFF, 0xF]).unwrap();
+        let seq = DacsByte::from_slice(&[0xFFFFusize, 0xFF, 0xF, 0xFFFFF, 0xF]);
 
         assert_eq!(
             seq.data,
@@ -331,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let seq = DacsByte::from_slice::<usize>(&[]).unwrap();
+        let seq = DacsByte::from_slice::<usize>(&[]);
         assert!(seq.is_empty());
         assert_eq!(seq.len(), 0);
         assert_eq!(seq.num_levels(), 1);
@@ -340,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_all_zeros() {
-        let seq = DacsByte::from_slice(&[0, 0, 0, 0]).unwrap();
+        let seq = DacsByte::from_slice(&[0usize, 0, 0, 0]);
         assert!(!seq.is_empty());
         assert_eq!(seq.len(), 4);
         assert_eq!(seq.num_levels(), 1);
@@ -352,18 +345,9 @@ mod tests {
     }
 
     #[test]
-    fn test_from_slice_uncastable() {
-        let e = DacsByte::from_slice(&[u128::MAX]);
-        assert_eq!(
-            e.err().map(|x| x.to_string()),
-            Some("vals must consist only of values castable into usize.".to_string())
-        );
-    }
-
-    #[test]
     fn test_serialize() {
         let mut bytes = vec![];
-        let seq = DacsByte::from_slice(&[0xFFFFF, 0xFF, 0xF, 0xFFFFF, 0xF]).unwrap();
+        let seq = DacsByte::from_slice(&[0xFFFFFu32, 0xFF, 0xF, 0xFFFFF, 0xF]);
         let size = seq.serialize_into(&mut bytes).unwrap();
         let other = DacsByte::deserialize_from(&bytes[..]).unwrap();
         assert_eq!(seq, other);

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -66,7 +66,7 @@ impl DacsByte {
     ///
     pub fn from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
     {
         if vals.is_empty() {
             return Self::default();
@@ -178,7 +178,7 @@ impl Build for DacsByte {
     /// This just calls [`Self::from_slice()`]. See the documentation.
     fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
         Self: Sized,
     {
         Self::from_slice(vals)

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -76,7 +76,7 @@ impl DacsByte {
         for x in vals {
             maxv = maxv.max((*x).into());
         }
-        let num_bits = utils::needed_bits(maxv.into());
+        let num_bits = utils::needed_bits(maxv);
         let num_levels = utils::ceiled_divide(num_bits, LEVEL_WIDTH);
         assert_ne!(num_levels, 0);
 

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -34,7 +34,7 @@ const LEVEL_MASK: u64 = (1 << LEVEL_WIDTH) - 1;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use sucds::int_vectors::{DacsByte, Access};
 ///
-/// let seq = DacsByte::from_slice(&[5, 0, 100000, 334])?;
+/// let seq = DacsByte::from_slice(&[5u64, 0, 100000, 334]);
 ///
 /// assert_eq!(seq.access(0), Some(5));
 /// assert_eq!(seq.access(1), Some(0));
@@ -122,7 +122,7 @@ impl DacsByte {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::DacsByte;
     ///
-    /// let seq = DacsByte::from_slice(&[5, 0, 100000, 334])?;
+    /// let seq = DacsByte::from_slice(&[5u64, 0, 100000, 334]);
     /// let mut it = seq.iter();
     ///
     /// assert_eq!(it.next(), Some(5));
@@ -206,7 +206,7 @@ impl Access for DacsByte {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::{DacsByte, Access};
     ///
-    /// let seq = DacsByte::from_slice(&[5, 999, 334]);
+    /// let seq = DacsByte::from_slice(&[5u64, 999, 334]);
     ///
     /// assert_eq!(seq.access(0), Some(5));
     /// assert_eq!(seq.access(1), Some(999));

--- a/src/int_vectors/dacs_byte.rs
+++ b/src/int_vectors/dacs_byte.rs
@@ -12,7 +12,7 @@ use crate::utils;
 use crate::Serializable;
 
 const LEVEL_WIDTH: usize = 8;
-const LEVEL_MASK: usize = (1 << LEVEL_WIDTH) - 1;
+const LEVEL_MASK: u64 = (1 << LEVEL_WIDTH) - 1;
 
 /// Compressed integer sequence using Directly Addressable Codes (DACs) in a simple bytewise scheme.
 ///
@@ -215,13 +215,13 @@ impl Access for DacsByte {
     /// # Ok(())
     /// # }
     /// ```
-    fn access(&self, mut pos: usize) -> Option<usize> {
+    fn access(&self, mut pos: usize) -> Option<u64> {
         if self.len() <= pos {
             return None;
         }
         let mut x = 0;
         for j in 0..self.num_levels() {
-            x |= usize::from(self.data[j][pos]) << (j * LEVEL_WIDTH);
+            x |= u64::from(self.data[j][pos]) << (j * LEVEL_WIDTH);
             if j == self.num_levels() - 1
                 || !bit_vectors::Access::access(&self.flags[j], pos).unwrap()
             {
@@ -247,7 +247,7 @@ impl<'a> Iter<'a> {
 }
 
 impl Iterator for Iter<'_> {
-    type Item = usize;
+    type Item = u64;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_basic() {
-        let seq = DacsByte::from_slice(&[0xFFFFusize, 0xFF, 0xF, 0xFFFFF, 0xF]);
+        let seq = DacsByte::from_slice(&[0xFFFFu64, 0xFF, 0xF, 0xFFFFF, 0xF]);
 
         assert_eq!(
             seq.data,
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let seq = DacsByte::from_slice::<usize>(&[]);
+        let seq = DacsByte::from_slice::<u64>(&[]);
         assert!(seq.is_empty());
         assert_eq!(seq.len(), 0);
         assert_eq!(seq.num_levels(), 1);
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_all_zeros() {
-        let seq = DacsByte::from_slice(&[0usize, 0, 0, 0]);
+        let seq = DacsByte::from_slice(&[0u64, 0, 0, 0]);
         assert!(!seq.is_empty());
         assert_eq!(seq.len(), 4);
         assert_eq!(seq.num_levels(), 1);

--- a/src/int_vectors/dacs_opt.rs
+++ b/src/int_vectors/dacs_opt.rs
@@ -78,7 +78,7 @@ impl DacsOpt {
     /// - `max_levels` is not within `1..=64` if it is [`Some`].
     pub fn from_slice<T>(vals: &[T], max_levels: Option<usize>) -> Result<Self>
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
     {
         let max_levels = max_levels.unwrap_or(64);
         if !(1..=64).contains(&max_levels) {
@@ -98,7 +98,7 @@ impl DacsOpt {
     // A modified implementation of Algorithm 3.5 in Navarro's book.
     fn compute_opt_widths<T>(vals: &[T], max_levels: usize) -> Vec<usize>
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
     {
         assert!(!vals.is_empty());
         assert_ne!(max_levels, 0);
@@ -181,7 +181,7 @@ impl DacsOpt {
 
     fn build<T>(vals: &[T], widths: &[usize]) -> Result<Self>
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
     {
         assert!(!vals.is_empty());
         assert!(!widths.is_empty());
@@ -286,7 +286,7 @@ impl Build for DacsOpt {
     /// This just calls [`Self::from_slice()`] with `max_levels == None`. See the documentation.
     fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
         Self: Sized,
     {
         Self::from_slice(vals, None).unwrap()

--- a/src/int_vectors/dacs_opt.rs
+++ b/src/int_vectors/dacs_opt.rs
@@ -323,7 +323,7 @@ impl Access for DacsOpt {
     /// # Ok(())
     /// # }
     /// ```
-    fn access(&self, mut pos: usize) -> Option<usize> {
+    fn access(&self, mut pos: usize) -> Option<u64> {
         if self.len() <= pos {
             return None;
         }
@@ -357,7 +357,7 @@ impl<'a> Iter<'a> {
 }
 
 impl Iterator for Iter<'_> {
-    type Item = usize;
+    type Item = u64;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -463,7 +463,7 @@ mod tests {
         //      0 = 0b0
         // 100000 = 0b11000011010100000
         //    334 = 0b101001110
-        let seq = DacsOpt::from_slice(&[5usize, 0, 100000, 334], None).unwrap();
+        let seq = DacsOpt::from_slice(&[5u64, 0, 100000, 334], None).unwrap();
 
         assert_eq!(
             seq.data,
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let seq = DacsOpt::from_slice::<usize>(&[], None).unwrap();
+        let seq = DacsOpt::from_slice::<u64>(&[], None).unwrap();
         assert!(seq.is_empty());
         assert_eq!(seq.len(), 0);
         assert_eq!(seq.num_levels(), 1);

--- a/src/int_vectors/dacs_opt.rs
+++ b/src/int_vectors/dacs_opt.rs
@@ -33,7 +33,7 @@ use crate::Serializable;
 /// use sucds::int_vectors::{DacsOpt, Access};
 ///
 /// // Specifies two for the maximum number of levels to control time efficiency.
-/// let seq = DacsOpt::from_slice(&[5usize, 0, 100000, 334], Some(2));
+/// let seq = DacsOpt::from_slice(&[5u64, 0, 100000, 334], Some(2))?;
 ///
 /// assert_eq!(seq.access(0), Some(5));
 /// assert_eq!(seq.access(1), Some(0));
@@ -231,7 +231,7 @@ impl DacsOpt {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::DacsOpt;
     ///
-    /// let seq = DacsOpt::from_slice(&[5usize, 0, 100000, 334], Some(2));
+    /// let seq = DacsOpt::from_slice(&[5u64, 0, 100000, 334], Some(2))?;
     /// let mut it = seq.iter();
     ///
     /// assert_eq!(it.next(), Some(5));
@@ -314,7 +314,7 @@ impl Access for DacsOpt {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::{DacsOpt, Access};
     ///
-    /// let seq = DacsOpt::from_slice(&[5usize, 999, 334], None);
+    /// let seq = DacsOpt::from_slice(&[5u64, 999, 334], None)?;
     ///
     /// assert_eq!(seq.access(0), Some(5));
     /// assert_eq!(seq.access(1), Some(999));

--- a/src/int_vectors/prefix_summed_elias_fano.rs
+++ b/src/int_vectors/prefix_summed_elias_fano.rs
@@ -79,7 +79,7 @@ impl PrefixSummedEliasFano {
     /// ```
     pub fn from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
     {
         let mut universe = 0;
         for x in vals {
@@ -139,7 +139,7 @@ impl Build for PrefixSummedEliasFano {
     /// This just calls [`Self::from_slice()`]. See the documentation.
     fn build_from_slice<T>(vals: &[T]) -> Self
     where
-        T: Into<usize> + Copy,
+        T: Into<u64> + Copy,
         Self: Sized,
     {
         Self::from_slice(vals)

--- a/src/int_vectors/prefix_summed_elias_fano.rs
+++ b/src/int_vectors/prefix_summed_elias_fano.rs
@@ -27,7 +27,7 @@ use crate::Serializable;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use sucds::int_vectors::{PrefixSummedEliasFano, Access};
 ///
-/// let seq = PrefixSummedEliasFano::from_slice(&[5, 14, 334, 10]);
+/// let seq = PrefixSummedEliasFano::from_slice(&[5u64, 14, 334, 10]);
 ///
 /// assert_eq!(seq.access(0), Some(5));
 /// assert_eq!(seq.access(1), Some(14));
@@ -70,7 +70,7 @@ impl PrefixSummedEliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::PrefixSummedEliasFano;
     ///
-    /// let seq = PrefixSummedEliasFano::from_slice(&[5, 14, 334, 10]);
+    /// let seq = PrefixSummedEliasFano::from_slice(&[5u64, 14, 334, 10]);
     ///
     /// assert_eq!(seq.len(), 4);
     /// assert_eq!(seq.sum(), 363);
@@ -102,7 +102,7 @@ impl PrefixSummedEliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::PrefixSummedEliasFano;
     ///
-    /// let seq = PrefixSummedEliasFano::from_slice(&[5, 14, 334, 10])?;
+    /// let seq = PrefixSummedEliasFano::from_slice(&[5u64, 14, 334, 10]);
     /// let mut it = seq.iter();
     ///
     /// assert_eq!(it.next(), Some(5));
@@ -166,7 +166,7 @@ impl Access for PrefixSummedEliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::int_vectors::{PrefixSummedEliasFano, Access};
     ///
-    /// let seq = PrefixSummedEliasFano::from_slice(&[5, 14, 334]);
+    /// let seq = PrefixSummedEliasFano::from_slice(&[5u64, 14, 334]);
     /// assert_eq!(seq.access(0), Some(5));
     /// assert_eq!(seq.access(1), Some(14));
     /// assert_eq!(seq.access(2), Some(334));

--- a/src/int_vectors/prefix_summed_elias_fano.rs
+++ b/src/int_vectors/prefix_summed_elias_fano.rs
@@ -128,7 +128,7 @@ impl PrefixSummedEliasFano {
     }
 
     /// Gets the sum of integers.
-    pub const fn sum(&self) -> usize {
+    pub const fn sum(&self) -> u64 {
         self.ef.universe() - 1
     }
 }
@@ -174,7 +174,7 @@ impl Access for PrefixSummedEliasFano {
     /// # Ok(())
     /// # }
     /// ```
-    fn access(&self, pos: usize) -> Option<usize> {
+    fn access(&self, pos: usize) -> Option<u64> {
         self.ef.delta(pos)
     }
 }
@@ -208,7 +208,7 @@ impl<'a> Iter<'a> {
 }
 
 impl Iterator for Iter<'_> {
-    type Item = usize;
+    type Item = u64;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -2,14 +2,14 @@
 #![cfg(feature = "intrinsics")]
 
 #[inline(always)]
-pub const fn popcount(x: usize) -> usize {
+pub const fn popcount(x: u64) -> usize {
     x.count_ones() as usize
 }
 
 #[inline(always)]
 pub const fn bsf64(mask: u64) -> Option<usize> {
     if mask != 0 {
-        Some(mask.trailing_zeros())
+        Some(mask.trailing_zeros() as usize)
     } else {
         None
     }
@@ -18,7 +18,7 @@ pub const fn bsf64(mask: u64) -> Option<usize> {
 #[inline(always)]
 pub const fn bsr64(mask: u64) -> Option<usize> {
     if mask != 0 {
-        Some(63 - mask.leading_zeros())
+        Some((63 - mask.leading_zeros()) as usize)
     } else {
         None
     }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -7,18 +7,18 @@ pub const fn popcount(x: usize) -> usize {
 }
 
 #[inline(always)]
-pub const fn bsf64(mask: usize) -> Option<usize> {
+pub const fn bsf64(mask: u64) -> Option<usize> {
     if mask != 0 {
-        Some(mask.trailing_zeros() as usize)
+        Some(mask.trailing_zeros())
     } else {
         None
     }
 }
 
 #[inline(always)]
-pub const fn bsr64(mask: usize) -> Option<usize> {
+pub const fn bsr64(mask: u64) -> Option<usize> {
     if mask != 0 {
-        Some(63 - mask.leading_zeros() as usize)
+        Some(63 - mask.leading_zeros())
     } else {
         None
     }

--- a/src/mii_sequences/elias_fano.rs
+++ b/src/mii_sequences/elias_fano.rs
@@ -699,6 +699,10 @@ mod tests {
     #[test]
     fn test_from_bits_empty() {
         let e = EliasFano::from_bits([]);
+        assert_eq!(
+            e.err().map(|x| x.to_string()),
+            Some("bits must not be empty.".to_string())
+        );
     }
 
     #[test]

--- a/src/mii_sequences/elias_fano.rs
+++ b/src/mii_sequences/elias_fano.rs
@@ -664,7 +664,7 @@ impl EliasFanoBuilder {
         I: IntoIterator<Item = u64>,
     {
         for x in vals {
-            self.push(x);
+            self.push(x)?;
         }
         Ok(())
     }

--- a/src/mii_sequences/elias_fano.rs
+++ b/src/mii_sequences/elias_fano.rs
@@ -32,8 +32,8 @@ const LINEAR_SCAN_THRESHOLD: usize = 64;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use sucds::mii_sequences::EliasFanoBuilder;
 ///
-/// let mut efb = EliasFanoBuilder::new(8, 4)?;
-/// efb.extend([1, 3, 3, 7])?;
+/// let mut efb = EliasFanoBuilder::new(8, 4);
+/// efb.extend([1, 3, 3, 7]);
 /// let ef = efb.build();
 ///
 /// assert_eq!(ef.len(), 4);
@@ -144,8 +144,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(8, 4)?;
-    /// efb.extend([1, 3, 3, 7])?;
+    /// let mut efb = EliasFanoBuilder::new(8, 4);
+    /// efb.extend([1, 3, 3, 7]);
     /// let ef = efb.build();
     ///
     /// assert_eq!(ef.delta(0), Some(1));
@@ -204,8 +204,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(11, 6)?;
-    /// efb.extend([1, 3, 3, 6, 7, 10])?;
+    /// let mut efb = EliasFanoBuilder::new(11, 6);
+    /// efb.extend([1, 3, 3, 6, 7, 10]);
     /// let ef = efb.build();
     ///
     /// assert_eq!(ef.binsearch(6), Some(3));
@@ -239,8 +239,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(11, 6)?;
-    /// efb.extend([1, 3, 3, 6, 7, 10])?;
+    /// let mut efb = EliasFanoBuilder::new(11, 6);
+    /// efb.extend([1, 3, 3, 6, 7, 10]);
     /// let ef = efb.build();
     ///
     /// assert_eq!(ef.binsearch_range(1..4, 6), Some(3));
@@ -299,8 +299,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(8, 4)?;
-    /// efb.extend([1, 3, 3, 7])?;
+    /// let mut efb = EliasFanoBuilder::new(8, 4);
+    /// efb.extend([1, 3, 3, 7]);
     /// let ef = efb.build().enable_rank();
     ///
     /// assert_eq!(ef.rank(3), Some(1));
@@ -351,8 +351,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(8, 4)?;
-    /// efb.extend([1, 3, 3, 7])?;
+    /// let mut efb = EliasFanoBuilder::new(8, 4);
+    /// efb.extend([1, 3, 3, 7]);
     /// let ef = efb.build();
     ///
     /// assert_eq!(ef.select(0), Some(1));
@@ -394,8 +394,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(8, 4)?;
-    /// efb.extend([1, 3, 3, 7])?;
+    /// let mut efb = EliasFanoBuilder::new(8, 4);
+    /// efb.extend([1, 3, 3, 7]);
     /// let ef = efb.build().enable_rank();
     ///
     /// assert_eq!(ef.predecessor(4), Some(3));
@@ -432,8 +432,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(8, 4)?;
-    /// efb.extend([1, 3, 3, 7])?;
+    /// let mut efb = EliasFanoBuilder::new(8, 4);
+    /// efb.extend([1, 3, 3, 7]);
     /// let ef = efb.build().enable_rank();
     ///
     /// assert_eq!(ef.successor(0), Some(1));
@@ -465,8 +465,8 @@ impl EliasFano {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use sucds::mii_sequences::EliasFanoBuilder;
     ///
-    /// let mut efb = EliasFanoBuilder::new(8, 4)?;
-    /// efb.extend([1, 3, 3, 7])?;
+    /// let mut efb = EliasFanoBuilder::new(8, 4);
+    /// efb.extend([1, 3, 3, 7]);
     /// let ef = efb.build();
     ///
     /// let mut it = ef.iter(1);
@@ -538,14 +538,14 @@ impl Serializable for EliasFano {
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use sucds::mii_sequences::EliasFanoBuilder;
 ///
-/// let mut efb = EliasFanoBuilder::new(8, 5)?;
+/// let mut efb = EliasFanoBuilder::new(8, 5);
 ///
 /// assert_eq!(efb.universe(), 8);
 /// assert_eq!(efb.num_vals(), 5);
 ///
-/// efb.push(1)?;
-/// efb.push(3)?;
-/// efb.extend([3, 5, 7])?;
+/// efb.push(1);
+/// efb.push(3);
+/// efb.extend([3, 5, 7]);
 ///
 /// let ef = efb.build();
 /// assert_eq!(ef.len(), 5);
@@ -664,7 +664,7 @@ impl EliasFanoBuilder {
         I: IntoIterator<Item = u64>,
     {
         for x in vals {
-            self.push(x)?;
+            self.push(x);
         }
         Ok(())
     }

--- a/src/mii_sequences/elias_fano.rs
+++ b/src/mii_sequences/elias_fano.rs
@@ -79,7 +79,7 @@ pub struct EliasFano {
     high_bits: DArray,
     low_bits: BitVector,
     low_len: usize,
-    universe: usize,
+    universe: u64,
 }
 
 impl EliasFano {
@@ -108,10 +108,10 @@ impl EliasFano {
         if m == 0 {
             return Err(anyhow!("bits must contains one set bit at least."));
         }
-        let mut b = EliasFanoBuilder::new(n, m);
+        let mut b = EliasFanoBuilder::new(n as u64, m);
         for i in 0..n {
             if bv.access(i).unwrap() {
-                b.push(i).unwrap();
+                b.push(i as u64).unwrap();
             }
         }
         Ok(b.build())
@@ -157,7 +157,7 @@ impl EliasFano {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn delta(&self, k: usize) -> Option<usize> {
+    pub fn delta(&self, k: usize) -> Option<u64> {
         if self.len() <= k {
             return None;
         }
@@ -165,7 +165,7 @@ impl EliasFano {
         let low_val = self
             .low_bits
             .get_bits(k * self.low_len, self.low_len)
-            .unwrap();
+            .unwrap() as usize;
         let x = if k != 0 {
             ((high_val
                 - self
@@ -179,11 +179,11 @@ impl EliasFano {
                 - self
                     .low_bits
                     .get_bits((k - 1) * self.low_len, self.low_len)
-                    .unwrap()
+                    .unwrap() as usize
         } else {
             ((high_val - k) << self.low_len) | low_val
         };
-        Some(x)
+        Some(x as u64)
     }
 
     /// Finds the position `k` such that `select(k) == val`.
@@ -215,7 +215,7 @@ impl EliasFano {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn binsearch(&self, val: usize) -> Option<usize> {
+    pub fn binsearch(&self, val: u64) -> Option<usize> {
         // TODO(kampersanda): Implement Access.
         self.binsearch_range(0..self.len(), val)
     }
@@ -250,7 +250,7 @@ impl EliasFano {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn binsearch_range(&self, range: Range<usize>, val: usize) -> Option<usize> {
+    pub fn binsearch_range(&self, range: Range<usize>, val: u64) -> Option<usize> {
         // TODO(kampersanda): Bound check.
         if range.is_empty() {
             return None;
@@ -260,7 +260,7 @@ impl EliasFano {
         let (mut lo, mut hi) = (range.start, range.end);
         while hi - lo > LINEAR_SCAN_THRESHOLD {
             let mi = (lo + hi) / 2;
-            let x = self.select(mi).unwrap();
+            let x = self.select(mi).unwrap() as u64;
             if val == x {
                 return Some(mi);
             }
@@ -311,10 +311,10 @@ impl EliasFano {
     /// # }
     /// ```
     pub fn rank(&self, pos: usize) -> Option<usize> {
-        if self.universe() < pos {
+        if self.universe() < pos as u64 {
             return None;
         }
-        if self.universe() == pos {
+        if self.universe() == pos as u64 {
             return Some(self.len());
         }
 
@@ -329,7 +329,7 @@ impl EliasFano {
                 .low_bits
                 .get_bits((rank - 1) * self.low_len, self.low_len)
                 .unwrap()
-                >= l_pos
+                >= l_pos as u64
         {
             rank -= 1;
             h_pos -= 1;
@@ -372,7 +372,7 @@ impl EliasFano {
                     | self
                         .low_bits
                         .get_bits(k * self.low_len, self.low_len)
-                        .unwrap(),
+                        .unwrap() as usize,
             )
         }
     }
@@ -406,7 +406,7 @@ impl EliasFano {
     /// # }
     /// ```
     pub fn predecessor(&self, pos: usize) -> Option<usize> {
-        if self.universe() <= pos {
+        if self.universe() <= pos as u64 {
             None
         } else {
             Some(self.rank(pos + 1).unwrap())
@@ -444,7 +444,7 @@ impl EliasFano {
     /// # }
     /// ```
     pub fn successor(&self, pos: usize) -> Option<usize> {
-        if self.universe() <= pos {
+        if self.universe() <= pos as u64 {
             None
         } else {
             Some(self.rank(pos).unwrap())
@@ -495,7 +495,7 @@ impl EliasFano {
 
     /// Returns the universe, i.e., the (exclusive) upper bound of possible integers.
     #[inline(always)]
-    pub const fn universe(&self) -> usize {
+    pub const fn universe(&self) -> u64 {
         self.universe
     }
 }
@@ -514,7 +514,7 @@ impl Serializable for EliasFano {
         let high_bits = DArray::deserialize_from(&mut reader)?;
         let low_bits = BitVector::deserialize_from(&mut reader)?;
         let low_len = usize::deserialize_from(&mut reader)?;
-        let universe = usize::deserialize_from(&mut reader)?;
+        let universe = u64::deserialize_from(&mut reader)?;
         Ok(Self {
             high_bits,
             low_bits,
@@ -556,10 +556,10 @@ impl Serializable for EliasFano {
 pub struct EliasFanoBuilder {
     high_bits: BitVector,
     low_bits: BitVector,
-    universe: usize,
+    universe: u64,
     num_vals: usize,
     pos: usize,
-    last: usize,
+    last: u64,
     low_len: usize,
 }
 
@@ -571,7 +571,7 @@ impl EliasFanoBuilder {
     /// - `universe`: The (exclusive) upper bound of integers to be stored, i.e., an integer in `[0..universe - 1]`.
     /// - `num_vals`: The number of integers that will be pushed (> 0).
     ///
-    pub fn new(universe: usize, num_vals: usize) -> Self {
+    pub fn new(universe: u64, num_vals: usize) -> Self {
         if num_vals == 0 {
             return Self {
                 high_bits: BitVector::new(),
@@ -583,9 +583,12 @@ impl EliasFanoBuilder {
                 low_len: 0,
             };
         }
-        let low_len = broadword::msb(universe / num_vals).unwrap_or(0);
+        let low_len = broadword::msb(universe / num_vals as u64).unwrap_or(0);
         Self {
-            high_bits: BitVector::from_bit(false, (num_vals + 1) + (universe >> low_len) + 1),
+            high_bits: BitVector::from_bit(
+                false,
+                (num_vals + 1) + (universe >> low_len) as usize + 1,
+            ),
             low_bits: BitVector::new(),
             universe,
             num_vals,
@@ -608,7 +611,7 @@ impl EliasFanoBuilder {
     /// - `val` is less than the last one,
     /// - `val` is no less than [`Self::universe()`], or
     /// - the number of stored integers becomes no less than [`Self::num_vals()`].
-    pub fn push(&mut self, val: usize) -> Result<()> {
+    pub fn push(&mut self, val: u64) -> Result<()> {
         if val < self.last {
             return Err(anyhow!(
                 "val must be no less than the last one {}, but got {val}.",
@@ -636,7 +639,7 @@ impl EliasFanoBuilder {
                 .unwrap();
         }
         self.high_bits
-            .set_bit((val >> self.low_len) + self.pos, true)
+            .set_bit((val as usize >> self.low_len) + self.pos, true)
             .unwrap();
         self.pos += 1;
 
@@ -658,7 +661,7 @@ impl EliasFanoBuilder {
     /// - the number of stored integers becomes no less than [`Self::num_vals()`].
     pub fn extend<I>(&mut self, vals: I) -> Result<()>
     where
-        I: IntoIterator<Item = usize>,
+        I: IntoIterator<Item = u64>,
     {
         for x in vals {
             self.push(x)?;
@@ -678,7 +681,7 @@ impl EliasFanoBuilder {
 
     /// Returns the universe, i.e., the (exclusive) upper bound of possible integers.
     #[inline(always)]
-    pub const fn universe(&self) -> usize {
+    pub const fn universe(&self) -> u64 {
         self.universe
     }
 

--- a/src/mii_sequences/elias_fano/iter.rs
+++ b/src/mii_sequences/elias_fano/iter.rs
@@ -10,8 +10,8 @@ pub struct Iter<'a> {
     ef: &'a EliasFano,
     k: usize,
     high_iter: Option<UnaryIter<'a>>,
-    low_buf: usize,
-    low_mask: usize,
+    low_buf: u64,
+    low_mask: u64,
     chunks_in_word: usize,
     chunks_avail: usize,
 }
@@ -51,7 +51,7 @@ impl<'a> Iter<'a> {
 }
 
 impl Iterator for Iter<'_> {
-    type Item = usize;
+    type Item = u64;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -69,9 +69,9 @@ impl Iterator for Iter<'_> {
             } else {
                 self.chunks_avail -= 1;
             }
-            let high = high_iter.next().unwrap();
+            let high = high_iter.next().unwrap() as u64;
             let low = self.low_buf & self.low_mask;
-            let ret = ((high - self.k) << self.ef.low_len) | low;
+            let ret = ((high - self.k as u64) << self.ef.low_len) | low;
             self.k += 1;
             self.low_buf >>= self.ef.low_len;
             Some(ret)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ use crate::broadword;
 /// assert_eq!(needed_bits(255), 8);
 /// assert_eq!(needed_bits(256), 9);
 /// ```
-pub fn needed_bits(x: usize) -> usize {
+pub fn needed_bits(x: u64) -> usize {
     broadword::msb(x).map_or(1, |n| n + 1)
 }
 


### PR DESCRIPTION
As proposed at <https://github.com/kampersanda/sucds/issues/104>, this mainly makes it easier to extend and create bit vectors with less error handling on run time and more at compile time, see the issue for more details.

This had huge ripple effects and took a lot of time so by the end I was rushing it a bit, I mean I got all tests and doc tests to compile and run successfully but still I think you need to check this in case I overlooked something, there is also surely more to do in the future in this area.

As usize is the same as u64 for the target bit width of 64 bit this is all a bit strange so I tried to make a quick call as to what the intent is (index vs value).
However in this library it is sometimes mixed or used to calculate one from the other, so I was not sure in all cases but also looked up how another library or the intrinsics are defined.

Please merge into a single commit, the commits of the PR before the last one do not compile or test correctly.
By the way I just saw at <https://github.com/Cydhra/vers/pull/34> that similar libraries seem to plan a similar refactoring at the same time :-)