### PR TITLE
Fix CI clippy failure

### DIFF
--- a/src/mii_sequences/elias_fano/iter.rs
+++ b/src/mii_sequences/elias_fano/iter.rs
@@ -26,6 +26,7 @@ impl<'a> Iter<'a> {
         let low_mask = (1 << ef.low_len) - 1;
 
         let (chunks_in_word, chunks_avail) = if ef.low_len != 0 {
+            // Safe because this branch guarantees that the divisor is nonzero.
             (64usize.checked_div(ef.low_len).unwrap(), 0)
         } else {
             (0, ef.len())

--- a/src/mii_sequences/elias_fano/iter.rs
+++ b/src/mii_sequences/elias_fano/iter.rs
@@ -26,7 +26,7 @@ impl<'a> Iter<'a> {
         let low_mask = (1 << ef.low_len) - 1;
 
         let (chunks_in_word, chunks_avail) = if ef.low_len != 0 {
-            (64 / ef.low_len, 0)
+            (64usize.checked_div(ef.low_len).unwrap(), 0)
         } else {
             (0, ef.len())
         };


### PR DESCRIPTION
## Summary
- express the guarded Elias-Fano chunk division with `checked_div` so it satisfies current Clippy

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings -W clippy::nursery`
- `cargo test --release`
- `cargo test --release --features intrinsics`
- `cargo doc --no-deps`

MSRV 1.68 could not be installed locally because rustup returned `Missing manifest`; the workflow will validate it on GitHub Actions.